### PR TITLE
API-first: envelope, auth, pagination, MCP server, API key auth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,22 @@ Backend requires these environment variables (set automatically by `just` comman
 3. Frontend stores in localStorage and adds to Authorization header
 4. Backend validates via `get_current_user` dependency
 
+### MCP API Key Authentication
+The MCP server supports automatic authentication via API key, avoiding password exposure in conversations.
+
+**Setup:**
+1. Start the backend and authenticate as a user
+2. Generate an API key: `POST /users/me/api-key` (authenticated) -- returns the key once
+3. Set `KIDS_REWARDS_API_KEY=<key>` in your `.mcp.json` env config
+4. The MCP server auto-authenticates on first API call and retries on 401
+
+**Key format:** `username.random_token` -- username prefix enables O(1) DynamoDB lookup.
+Only the bcrypt hash of the token part is stored; the full key is shown once at generation.
+
+**Endpoints:**
+- `POST /users/me/api-key` -- generate API key (authenticated, returns plaintext once)
+- `POST /auth/api-key` -- exchange API key for JWT (unauthenticated, body: `{"api_key": "..."}`)
+
 ### Role-Based Access
 - **Parent role**: Creating chores, managing store, approving purchases, managing pets
 - **Kid role**: Completing chores, requesting purchases, viewing assigned tasks

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -163,6 +163,26 @@ def update_user_points(username: str, points_to_add: int) -> Optional[models.Use
         return None
 
 
+def set_user_api_key_hash(username: str, key_hash: str) -> Optional[models.User]:
+    user = get_user_by_username(username)
+    if not user:
+        return None
+    try:
+        response = users_table.update_item(
+            Key={"username": username},
+            UpdateExpression="SET api_key_hash = :h",
+            ExpressionAttributeValues={":h": key_hash},
+            ReturnValues="ALL_NEW",
+        )
+        updated = response.get("Attributes")
+        if updated:
+            return models.User(**replace_decimals(updated))
+        return None
+    except ClientError as e:
+        logger.error("Error setting API key hash for %s: %s", username, e)
+        return None
+
+
 def promote_user_to_parent(username: str) -> Optional[models.User]:
     user = get_user_by_username(username)
     if not user:

--- a/backend/envelope.py
+++ b/backend/envelope.py
@@ -35,7 +35,7 @@ class ApiResponse(BaseModel):
     meta: Optional[dict] = None
 
 
-SKIP_PATHS = {"/token", "/health", "/", "/hello", "/openapi.json", "/docs", "/redoc"}
+SKIP_PATHS = {"/token", "/health", "/", "/hello", "/openapi.json", "/docs", "/redoc", "/auth/api-key"}
 
 
 def _should_wrap(path: str) -> bool:

--- a/backend/envelope.py
+++ b/backend/envelope.py
@@ -1,0 +1,166 @@
+import json
+from enum import Enum
+from typing import Any, Optional
+
+from fastapi import Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class ErrorCode(str, Enum):
+    NOT_FOUND = "NOT_FOUND"
+    ALREADY_EXISTS = "ALREADY_EXISTS"
+    INVALID_CREDENTIALS = "INVALID_CREDENTIALS"
+    INSUFFICIENT_POINTS = "INSUFFICIENT_POINTS"
+    FORBIDDEN = "FORBIDDEN"
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    BAD_REQUEST = "BAD_REQUEST"
+    NOT_PENDING = "NOT_PENDING"
+    INTERNAL_ERROR = "INTERNAL_ERROR"
+
+
+class ApiError(BaseModel):
+    code: str
+    message: str
+    details: Optional[dict] = None
+
+
+class ApiResponse(BaseModel):
+    success: bool
+    data: Any = None
+    error: Optional[ApiError] = None
+    meta: Optional[dict] = None
+
+
+SKIP_PATHS = {"/token", "/health", "/", "/hello", "/openapi.json", "/docs", "/redoc"}
+
+
+def _should_wrap(path: str) -> bool:
+    if path in SKIP_PATHS:
+        return False
+    if path.startswith("/docs") or path.startswith("/redoc") or path.startswith("/openapi"):
+        return False
+    return True
+
+
+def _status_to_error_code(status_code: int, detail: str = "") -> str:
+    detail_lower = detail.lower()
+    if status_code == 401:
+        return ErrorCode.INVALID_CREDENTIALS
+    if status_code == 403:
+        return ErrorCode.FORBIDDEN
+    if status_code == 404:
+        return ErrorCode.NOT_FOUND
+    if status_code == 422:
+        return ErrorCode.VALIDATION_ERROR
+    if status_code == 400:
+        if "already" in detail_lower:
+            return ErrorCode.ALREADY_EXISTS
+        if (
+            "not enough points" in detail_lower
+            or "insufficient" in detail_lower
+            or "no longer has enough" in detail_lower
+        ):
+            return ErrorCode.INSUFFICIENT_POINTS
+        if "not pending" in detail_lower:
+            return ErrorCode.NOT_PENDING
+        return ErrorCode.BAD_REQUEST
+    return ErrorCode.INTERNAL_ERROR
+
+
+def error_response(status_code: int, code: str, message: str, details: dict = None) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content=jsonable_encoder(
+            ApiResponse(
+                success=False,
+                error=ApiError(code=code, message=message, details=details),
+            )
+        ),
+    )
+
+
+def success_response(data: Any, status_code: int = 200, meta: dict = None) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content=jsonable_encoder(ApiResponse(success=True, data=data, meta=meta)),
+    )
+
+
+def register_exception_handlers(app):
+    @app.exception_handler(RequestValidationError)
+    async def validation_exception_handler(request: Request, exc: RequestValidationError):
+        if not _should_wrap(request.url.path):
+            return JSONResponse(status_code=422, content={"detail": exc.errors()})
+        errors = exc.errors()
+        fields = [
+            {"field": ".".join(str(loc) for loc in e.get("loc", [])), "message": e.get("msg", "")} for e in errors
+        ]
+        return error_response(
+            status_code=422,
+            code=ErrorCode.VALIDATION_ERROR,
+            message="Validation error",
+            details={"fields": fields},
+        )
+
+
+def _wrap_error(original: dict, status_code: int) -> JSONResponse:
+    detail = original.get("detail", "")
+    if isinstance(detail, list):
+        detail = str(detail)
+    code = _status_to_error_code(status_code, detail)
+    return JSONResponse(
+        status_code=status_code,
+        content=jsonable_encoder(
+            ApiResponse(
+                success=False,
+                error=ApiError(code=code, message=detail if detail else "An error occurred"),
+            )
+        ),
+    )
+
+
+def _wrap_success(original: Any, status_code: int) -> JSONResponse:
+    meta = {}
+    if isinstance(original, list):
+        meta["count"] = len(original)
+    return JSONResponse(
+        status_code=status_code,
+        content=jsonable_encoder(ApiResponse(success=True, data=original, meta=meta if meta else None)),
+    )
+
+
+class EnvelopeMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        if not _should_wrap(request.url.path):
+            return await call_next(request)
+
+        response = await call_next(request)
+
+        if response.status_code == 204:
+            return JSONResponse(
+                status_code=200,
+                content=jsonable_encoder(ApiResponse(success=True, data=None)),
+            )
+
+        body_bytes = b""
+        async for chunk in response.body_iterator:
+            body_bytes += chunk.encode("utf-8") if isinstance(chunk, str) else chunk
+
+        try:
+            original = json.loads(body_bytes)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return response
+
+        if isinstance(original, dict) and "success" in original:
+            return JSONResponse(status_code=response.status_code, content=original)
+
+        if response.status_code >= 400:
+            if isinstance(original, dict):
+                return _wrap_error(original, response.status_code)
+            return _wrap_error({}, response.status_code)
+
+        return _wrap_success(original, response.status_code)

--- a/backend/main.py
+++ b/backend/main.py
@@ -184,9 +184,7 @@ async def auth_with_api_key(api_key: str = Body(..., embed=True)):
     if not security.verify_password(token_part, user.api_key_hash):
         raise HTTPException(status_code=401, detail="Invalid API key")
     access_token_expires = timedelta(minutes=security.ACCESS_TOKEN_EXPIRE_MINUTES)
-    access_token = security.create_access_token(
-        data={"sub": user.username}, expires_delta=access_token_expires
-    )
+    access_token = security.create_access_token(data={"sub": user.username}, expires_delta=access_token_expires)
     return {"access_token": access_token, "token_type": "bearer"}
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -140,7 +140,10 @@ async def read_users_me(current_user: models.User = Depends(get_current_active_u
 
 
 @app.post("/users/promote-to-parent", response_model=models.User)
-async def promote_user_to_parent_endpoint(promotion_request: models.UserPromoteRequest):
+async def promote_user_to_parent_endpoint(
+    promotion_request: models.UserPromoteRequest,
+    current_parent: models.User = Depends(get_current_parent_user),  # noqa: B008
+):
     user_to_promote = crud.promote_user_to_parent(promotion_request.username)
     if not user_to_promote:
         raise HTTPException(
@@ -151,7 +154,10 @@ async def promote_user_to_parent_endpoint(promotion_request: models.UserPromoteR
 
 # --- Points Management Endpoints ---
 @app.post("/kids/award-points/", response_model=models.User)
-async def award_points_to_kid(award: models.PointsAward):
+async def award_points_to_kid(
+    award: models.PointsAward,
+    current_parent: models.User = Depends(get_current_parent_user),  # noqa: B008
+):
     kid_user = crud.get_user_by_username(award.kid_username)
     if not kid_user or kid_user.role != models.UserRole.KID:
         raise HTTPException(status_code=404, detail="Kid user not found or user is not a kid")
@@ -198,7 +204,10 @@ async def request_redeem_store_item(  # Renamed function for clarity
 
 # --- Store Item Endpoints ---
 @app.post("/store/items/", response_model=models.StoreItem, status_code=status.HTTP_201_CREATED)
-async def create_store_item(item: models.StoreItemCreate):
+async def create_store_item(
+    item: models.StoreItemCreate,
+    current_parent: models.User = Depends(get_current_parent_user),  # noqa: B008
+):
     return crud.create_store_item(item_in=item)
 
 
@@ -217,7 +226,11 @@ async def read_store_item(item_id: str):
 
 
 @app.put("/store/items/{item_id}", response_model=models.StoreItem)
-async def update_store_item(item_id: str, item: models.StoreItemCreate):
+async def update_store_item(
+    item_id: str,
+    item: models.StoreItemCreate,
+    current_parent: models.User = Depends(get_current_parent_user),  # noqa: B008
+):
     db_item = crud.update_store_item(item_id=item_id, item_in=item)
     if db_item is None:
         raise HTTPException(status_code=404, detail="Store item not found")
@@ -225,7 +238,10 @@ async def update_store_item(item_id: str, item: models.StoreItemCreate):
 
 
 @app.delete("/store/items/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_store_item(item_id: str):
+async def delete_store_item(
+    item_id: str,
+    current_parent: models.User = Depends(get_current_parent_user),  # noqa: B008
+):
     success = crud.delete_store_item(item_id=item_id)
     if not success:
         raise HTTPException(status_code=404, detail="Store item not found")
@@ -648,17 +664,18 @@ class PurchaseActionRequest(models.BaseModel):
 
 
 @app.get("/parent/purchase-requests/pending", response_model=List[models.PurchaseLog])  # noqa: UP006
-async def get_pending_purchase_requests():
-    """
-    Retrieve all purchase requests with 'pending' status.
-    Sorted by timestamp descending (newest first).
-    """
+async def get_pending_purchase_requests(
+    current_parent: models.User = Depends(get_current_parent_user),  # noqa: B008
+):
     pending_logs = crud.get_purchase_logs_by_status(models.PurchaseStatus.PENDING)
     return pending_logs
 
 
 @app.post("/parent/purchase-requests/approve", response_model=models.PurchaseLog)
-async def approve_purchase_request(request_data: PurchaseActionRequest):
+async def approve_purchase_request(
+    request_data: PurchaseActionRequest,
+    current_parent: models.User = Depends(get_current_parent_user),  # noqa: B008
+):
     log_to_approve = crud.get_purchase_log_by_id(request_data.log_id)  # Assumes get_purchase_log_by_id exists
 
     if not log_to_approve:
@@ -706,7 +723,10 @@ async def approve_purchase_request(request_data: PurchaseActionRequest):
 
 
 @app.post("/parent/purchase-requests/reject", response_model=models.PurchaseLog)
-async def reject_purchase_request(request_data: PurchaseActionRequest):
+async def reject_purchase_request(
+    request_data: PurchaseActionRequest,
+    current_parent: models.User = Depends(get_current_parent_user),  # noqa: B008
+):
     log_to_reject = crud.get_purchase_log_by_id(request_data.log_id)  # Assumes get_purchase_log_by_id exists
 
     if not log_to_reject:
@@ -1317,3 +1337,161 @@ async def get_pet_care_overview(
         )
 
     return {"pets": overview}
+
+
+# --- API-First: Missing GET-by-ID endpoints ---
+
+
+@app.get("/purchase-logs/{log_id}", response_model=models.PurchaseLog)
+async def get_purchase_log(
+    log_id: str,
+    current_user: models.User = Depends(get_current_active_user),  # noqa: B008
+):
+    log = crud.get_purchase_log_by_id(log_id)
+    if not log:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Purchase log not found.")
+    return log
+
+
+@app.get("/chore-logs/{log_id}", response_model=models.ChoreLog)
+async def get_chore_log(
+    log_id: str,
+    current_user: models.User = Depends(get_current_active_user),  # noqa: B008
+):
+    log = crud.get_chore_log_by_id(log_id)
+    if not log:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Chore log not found.")
+    return log
+
+
+@app.get("/requests/{request_id}", response_model=models.Request)
+async def get_request(
+    request_id: str,
+    current_user: models.User = Depends(get_current_active_user),  # noqa: B008
+):
+    req = crud.get_request_by_id(request_id)
+    if not req:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Request not found.")
+    return req
+
+
+@app.get("/chore-assignments/{assignment_id}", response_model=models.ChoreAssignment)
+async def get_assignment(
+    assignment_id: str,
+    current_user: models.User = Depends(get_current_active_user),  # noqa: B008
+):
+    assignment = crud.get_assignment_by_id(assignment_id)
+    if not assignment:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Assignment not found.")
+    return assignment
+
+
+@app.get("/pets/tasks/{task_id}", response_model=models.PetCareTask)
+async def get_pet_care_task(
+    task_id: str,
+    current_user: models.User = Depends(get_current_active_user),  # noqa: B008
+):
+    task = crud.get_task_by_id(task_id)
+    if not task:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Pet care task not found.")
+    return task
+
+
+@app.get("/pets/schedules/{schedule_id}", response_model=models.PetCareSchedule)
+async def get_schedule(
+    schedule_id: str,
+    current_user: models.User = Depends(get_current_active_user),  # noqa: B008
+):
+    schedule = crud.get_schedule_by_id(schedule_id)
+    if not schedule:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Schedule not found.")
+    return schedule
+
+
+# --- API-First: Admin/System endpoints ---
+
+
+@app.get("/users/", response_model=List[models.User])  # noqa: UP006
+async def list_users(
+    current_parent: models.User = Depends(get_current_parent_user),  # noqa: B008
+):
+    return crud.get_all_users()
+
+
+# --- API-First: Dashboard endpoints ---
+
+
+@app.get("/parent/dashboard")
+async def get_parent_dashboard(
+    current_parent: models.User = Depends(get_current_parent_user),  # noqa: B008
+):
+    pending_chores = crud.get_chore_logs_by_status_for_parent(
+        status=models.ChoreStatus.PENDING_APPROVAL, parent_id=current_parent.id
+    )
+    pending_purchases = crud.get_purchase_logs_by_status(models.PurchaseStatus.PENDING)
+    pending_assignments = crud.get_assignments_by_status_for_parent(
+        status=models.ChoreAssignmentStatus.SUBMITTED, parent_id=current_parent.id
+    )
+    pending_requests = crud.get_requests_by_status(status=models.RequestStatus.PENDING)
+    pending_pet_tasks = crud.get_tasks_by_status(models.PetCareTaskStatus.PENDING_APPROVAL)
+    parent_pets = crud.get_pets_by_parent_id(current_parent.id)
+    parent_pet_ids = {pet.id for pet in parent_pets}
+    pending_pet_tasks = [t for t in pending_pet_tasks if t.pet_id in parent_pet_ids]
+
+    return {
+        "pending_chore_submissions": len(pending_chores),
+        "pending_purchase_requests": len(pending_purchases),
+        "pending_assignment_submissions": len(pending_assignments),
+        "pending_feature_requests": len(pending_requests),
+        "pending_pet_task_submissions": len(pending_pet_tasks),
+    }
+
+
+@app.get("/kid/dashboard")
+async def get_kid_dashboard(
+    current_kid: models.User = Depends(get_current_kid_user),  # noqa: B008
+):
+    assignments = crud.get_assignments_by_kid_id(kid_id=current_kid.username)
+    active_assignments = [a for a in assignments if a.assignment_status == models.ChoreAssignmentStatus.ASSIGNED]
+    pet_tasks = crud.get_tasks_by_kid_id(kid_id=current_kid.username)
+    active_pet_tasks = [
+        t for t in pet_tasks if t.status in (models.PetCareTaskStatus.ASSIGNED, models.PetCareTaskStatus.SCHEDULED)
+    ]
+    streak_data = crud.calculate_streak_for_kid(kid_id=current_kid.username)
+
+    return {
+        "points": current_kid.points or 0,
+        "active_assignments": len(active_assignments),
+        "active_pet_tasks": len(active_pet_tasks),
+        "streak": streak_data,
+    }
+
+
+# --- API-First: Chore stats endpoint ---
+
+
+@app.get("/chores/history/me/stats")
+async def get_my_chore_stats(
+    current_kid: models.User = Depends(get_current_kid_user),  # noqa: B008
+):
+    chore_logs = crud.get_chore_logs_by_kid_id(kid_id=current_kid.id)
+    total_submitted = len(chore_logs)
+    approved = [cl for cl in chore_logs if cl.status == models.ChoreStatus.APPROVED]
+    rejected = [cl for cl in chore_logs if cl.status == models.ChoreStatus.REJECTED]
+    total_effort_minutes = sum(cl.effort_minutes or 0 for cl in chore_logs)
+    total_effort_points = sum(cl.effort_points or 0 for cl in chore_logs)
+    total_points_earned = sum(cl.points_value for cl in approved)
+    retry_count = sum(1 for cl in chore_logs if cl.is_retry)
+    high_effort = sum(1 for cl in chore_logs if (cl.effort_minutes or 0) >= 10)
+
+    return {
+        "total_submitted": total_submitted,
+        "total_approved": len(approved),
+        "total_rejected": len(rejected),
+        "total_effort_minutes": total_effort_minutes,
+        "total_effort_points": total_effort_points,
+        "total_points_earned": total_points_earned,
+        "retry_count": retry_count,
+        "high_effort_count": high_effort,
+        "average_effort_minutes": round(total_effort_minutes / total_submitted, 1) if total_submitted else 0,
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -86,7 +86,13 @@ async def verify_home_assistant_api_key(x_ha_api_key: Optional[str] = Header(Non
 
 app = FastAPI(title="Kids Rewards API", version="1.0.0")
 
-# --- CORS Middleware ---
+# --- Response Envelope Middleware ---
+from envelope import EnvelopeMiddleware, register_exception_handlers, success_response  # noqa: E402
+
+app.add_middleware(EnvelopeMiddleware)
+register_exception_handlers(app)
+
+# --- CORS Middleware (must be outermost to add headers AFTER envelope wrapping) ---
 origins = [
     "http://localhost:3000",
     "http://localhost:3001",
@@ -102,12 +108,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-# --- Response Envelope Middleware ---
-from envelope import EnvelopeMiddleware, register_exception_handlers, success_response  # noqa: E402
-
-app.add_middleware(EnvelopeMiddleware)
-register_exception_handlers(app)
 
 
 def paginated_response(items: list, limit: int, offset: int, total: int | None = None):

--- a/backend/main.py
+++ b/backend/main.py
@@ -75,26 +75,30 @@ async def get_current_kid_user(current_user: models.User = Depends(get_current_a
     return current_user
 
 
-app = FastAPI()
+app = FastAPI(title="Kids Rewards API", version="1.0.0")
 
 # --- CORS Middleware ---
 origins = [
-    "http://localhost:3000",  # React default dev port
-    "http://localhost:3001",  # Frontend dev server port
-    "http://localhost:3000",  # Backend server port
+    "http://localhost:3000",
+    "http://localhost:3001",
     "https://main.dd0mqanef4wnt.amplifyapp.com",
     "https://monkeypoints.shop",
-    "https://www.monkeypoints.shop",  # Deployed Amplify frontend
-    # Add other domains here
+    "https://www.monkeypoints.shop",
 ]
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
     allow_credentials=True,
-    allow_methods=["*"],  # Allows all methods
-    allow_headers=["*"],  # Allows all headers
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
+
+# --- Response Envelope Middleware ---
+from envelope import EnvelopeMiddleware, register_exception_handlers  # noqa: E402
+
+app.add_middleware(EnvelopeMiddleware)
+register_exception_handlers(app)
 
 # --- Endpoints ---
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -25,6 +25,7 @@ class User(UserBase):  # User still has a role
     id: str  # Or int, depending on DB
     hashed_password: str
     points: Optional[int] = None  # Only applicable for kids
+    api_key_hash: Optional[str] = None
 
     class Config:
         from_attributes = True  # For Pydantic V2
@@ -413,3 +414,8 @@ class ChoreAssignmentApprovalRequest(BaseModel):
     assignment_id: str
     approve: bool  # True to approve, False to reject
     # parent_id will be from the authenticated user
+
+
+class ApiKeyResponse(BaseModel):
+    api_key: str
+    message: str

--- a/backend/security.py
+++ b/backend/security.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -60,3 +61,21 @@ def decode_access_token(token: str) -> Optional[str]:
         return username
     except JWTError:
         return None
+
+
+def generate_api_key(username: str) -> tuple[str, str]:
+    token_part = secrets.token_urlsafe(24)
+    full_key = f"{username}.{token_part}"
+    key_hash = pwd_context.hash(token_part)
+    return full_key, key_hash
+
+
+def verify_api_key(api_key: str) -> Optional[tuple[str, str]]:
+    dot_index = api_key.find(".")
+    if dot_index < 1:
+        return None
+    username = api_key[:dot_index]
+    token_part = api_key[dot_index + 1 :]
+    if not token_part:
+        return None
+    return username, token_part

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,44 +1,225 @@
 import os
 import sys
+import uuid
+from datetime import datetime, timezone
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
-
 
 import pytest
 from fastapi.testclient import TestClient
 
 from backend.main import (
-    app,  # Corrected import: Assuming FastAPI app is in main.py at the root of the backend directory
+    app,
+    get_current_active_user,
+    get_current_kid_user,
+    get_current_parent_user,
 )
 
-# Calculate the project root (two levels up from backend/tests/conftest.py)
-# and add it to sys.path.
-# This ensures that the 'backend' package can be imported correctly (e.g., 'from backend.main import app')
-# and that relative imports within the 'backend' package (e.g., 'from .models import ...' in main.py)
-# work correctly during test execution.
 _current_file_dir = os.path.dirname(os.path.abspath(__file__))
 _project_root = os.path.abspath(os.path.join(_current_file_dir, "..", ".."))
 
 
+TEST_SECRET_KEY = os.environ.get("APP_SECRET_KEY", "test-secret-key-for-pre-commit-hook-validation-32chars")
+
+
+def make_user(role="parent", username=None, points=None):
+    from backend.models import User, UserRole
+
+    if username is None:
+        username = f"test-{role}-{uuid.uuid4().hex[:6]}"
+    user_id = f"user-{uuid.uuid4().hex[:8]}"
+    return User(
+        id=user_id,
+        username=username,
+        role=UserRole(role),
+        hashed_password="$2b$12$fakehash",
+        points=points if role == "kid" else None,
+    )
+
+
+PARENT_USER = make_user("parent", "testparent")
+KID_USER = make_user("kid", "testkid", points=100)
+
+
+def _override_parent():
+    return PARENT_USER
+
+
+def _override_kid():
+    return KID_USER
+
+
+def _override_active_parent():
+    return PARENT_USER
+
+
+def _override_active_kid():
+    return KID_USER
+
+
 @pytest.fixture(scope="module")
 def client():
-    """
-    Yield a TestClient instance that can be used to send requests to the application.
-    """
     with TestClient(app) as c:
         yield c
 
 
-# You can add more fixtures here as needed, for example, for database setup/teardown
-# or for creating mock services.
+@pytest.fixture()
+def api():
+    app.dependency_overrides[get_current_parent_user] = _override_parent
+    app.dependency_overrides[get_current_kid_user] = _override_kid
+    app.dependency_overrides[get_current_active_user] = _override_active_parent
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
 
-# Example fixture for a mock database (replace with your actual setup if needed)
-# @pytest.fixture(scope="function")
-# def mock_db_session():
-#     print("Setting up mock DB session")
-#     # Setup mock database or use a test database
-#     db = ... # Your mock/test database connection
-#     yield db
-#     print("Tearing down mock DB session")
-#     # Teardown mock database
-#     db.close()
+
+@pytest.fixture()
+def parent_api():
+    app.dependency_overrides[get_current_parent_user] = _override_parent
+    app.dependency_overrides[get_current_active_user] = _override_active_parent
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def kid_api():
+    app.dependency_overrides[get_current_kid_user] = _override_kid
+    app.dependency_overrides[get_current_active_user] = _override_active_kid
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture()
+def parent_user():
+    return PARENT_USER
+
+
+@pytest.fixture()
+def kid_user():
+    return KID_USER
+
+
+def make_chore(parent_id=None, **overrides):
+    defaults = {
+        "id": f"chore-{uuid.uuid4().hex[:8]}",
+        "name": "Test Chore",
+        "description": "A test chore",
+        "points_value": 10,
+        "created_by_parent_id": parent_id or PARENT_USER.id,
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+        "is_active": True,
+    }
+    defaults.update(overrides)
+    from backend.models import Chore
+
+    return Chore(**defaults)
+
+
+def make_store_item(**overrides):
+    defaults = {
+        "id": f"item-{uuid.uuid4().hex[:8]}",
+        "name": "Test Item",
+        "description": "A test store item",
+        "points_cost": 25,
+    }
+    defaults.update(overrides)
+    from backend.models import StoreItem
+
+    return StoreItem(**defaults)
+
+
+def make_purchase_log(user=None, item=None, **overrides):
+    from backend.models import PurchaseLog, PurchaseStatus
+
+    user = user or KID_USER
+    defaults = {
+        "id": f"purchase-{uuid.uuid4().hex[:8]}",
+        "user_id": user.id,
+        "username": user.username,
+        "item_id": item.id if item else f"item-{uuid.uuid4().hex[:8]}",
+        "item_name": item.name if item else "Test Item",
+        "points_spent": item.points_cost if item else 25,
+        "timestamp": datetime.now(timezone.utc),
+        "status": PurchaseStatus.PENDING,
+    }
+    defaults.update(overrides)
+    return PurchaseLog(**defaults)
+
+
+def make_chore_log(kid=None, chore=None, **overrides):
+    from backend.models import ChoreLog, ChoreStatus
+
+    kid = kid or KID_USER
+    defaults = {
+        "id": f"log-{uuid.uuid4().hex[:8]}",
+        "chore_id": chore.id if chore else f"chore-{uuid.uuid4().hex[:8]}",
+        "chore_name": chore.name if chore else "Test Chore",
+        "kid_id": kid.id,
+        "kid_username": kid.username,
+        "points_value": chore.points_value if chore else 10,
+        "status": ChoreStatus.PENDING_APPROVAL,
+        "submitted_at": datetime.now(timezone.utc),
+        "effort_minutes": 0,
+        "retry_count": 0,
+        "effort_points": 0,
+        "is_retry": False,
+    }
+    defaults.update(overrides)
+    return ChoreLog(**defaults)
+
+
+def make_pet(parent_id=None, **overrides):
+    from backend.models import Pet, PetSpecies
+
+    defaults = {
+        "id": f"pet-{uuid.uuid4().hex[:8]}",
+        "name": "Test Pet",
+        "species": PetSpecies.BEARDED_DRAGON,
+        "birthday": datetime(2024, 6, 1, tzinfo=timezone.utc),
+        "parent_id": parent_id or PARENT_USER.id,
+        "is_active": True,
+        "created_at": datetime.now(timezone.utc),
+        "updated_at": datetime.now(timezone.utc),
+    }
+    defaults.update(overrides)
+    return Pet(**defaults)
+
+
+def make_assignment(kid=None, chore=None, parent_id=None, **overrides):
+    from backend.models import ChoreAssignment, ChoreAssignmentStatus
+
+    kid = kid or KID_USER
+    defaults = {
+        "id": f"assign-{uuid.uuid4().hex[:8]}",
+        "chore_id": chore.id if chore else f"chore-{uuid.uuid4().hex[:8]}",
+        "chore_name": chore.name if chore else "Test Chore",
+        "assigned_to_kid_id": kid.username,
+        "kid_username": kid.username,
+        "assigned_by_parent_id": parent_id or PARENT_USER.id,
+        "points_value": chore.points_value if chore else 10,
+        "due_date": datetime.now(timezone.utc),
+        "assignment_status": ChoreAssignmentStatus.ASSIGNED,
+        "created_at": datetime.now(timezone.utc),
+    }
+    defaults.update(overrides)
+    return ChoreAssignment(**defaults)
+
+
+def make_request(kid=None, **overrides):
+    from backend.models import Request, RequestStatus, RequestType
+
+    kid = kid or KID_USER
+    defaults = {
+        "id": f"req-{uuid.uuid4().hex[:8]}",
+        "requester_id": kid.id,
+        "requester_username": kid.username,
+        "request_type": RequestType.OTHER,
+        "details": {"message": "test request"},
+        "status": RequestStatus.PENDING,
+        "created_at": datetime.now(timezone.utc),
+    }
+    defaults.update(overrides)
+    return Request(**defaults)

--- a/backend/tests/helpers.py
+++ b/backend/tests/helpers.py
@@ -1,0 +1,41 @@
+def assert_envelope(response, status_code=200):
+    assert response.status_code == status_code, f"Expected {status_code}, got {response.status_code}: {response.text}"
+    body = response.json()
+    assert "success" in body, f"Missing 'success' field: {body}"
+    assert "data" in body, f"Missing 'data' field: {body}"
+    assert body["success"] is True, f"Expected success=True: {body}"
+    return body["data"]
+
+
+def assert_envelope_list(response, status_code=200, min_count=None, max_count=None):
+    data = assert_envelope(response, status_code)
+    assert isinstance(data, list), f"Expected list, got {type(data)}: {data}"
+    body = response.json()
+    assert "meta" in body, f"Missing 'meta' field: {body}"
+    if min_count is not None:
+        assert len(data) >= min_count, f"Expected >= {min_count} items, got {len(data)}"
+    if max_count is not None:
+        assert len(data) <= max_count, f"Expected <= {max_count} items, got {len(data)}"
+    return data
+
+
+def assert_error(response, status_code, error_code=None):
+    assert response.status_code == status_code, f"Expected {status_code}, got {response.status_code}: {response.text}"
+    body = response.json()
+    assert "success" in body, f"Missing 'success' field: {body}"
+    assert body["success"] is False, f"Expected success=False: {body}"
+    assert "error" in body, f"Missing 'error' field: {body}"
+    error = body["error"]
+    assert "code" in error, f"Missing 'code' in error: {error}"
+    assert "message" in error, f"Missing 'message' in error: {error}"
+    if error_code:
+        assert error["code"] == error_code, f"Expected error code '{error_code}', got '{error['code']}'"
+    return error
+
+
+def assert_paginated(response, status_code=200):
+    data = assert_envelope_list(response, status_code)
+    body = response.json()
+    meta = body["meta"]
+    assert "cursor" in meta or "total" in meta, f"Missing pagination info in meta: {meta}"
+    return data, meta

--- a/backend/tests/test_api_key.py
+++ b/backend/tests/test_api_key.py
@@ -1,0 +1,102 @@
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import PARENT_USER, make_user
+
+
+@pytest.fixture()
+def parent_api_with_crud(parent_api):
+    return parent_api
+
+
+def _mock_get_user(user):
+    return patch("crud.get_user_by_username", return_value=user)
+
+
+def _mock_set_key(user):
+    return patch("crud.set_user_api_key_hash", return_value=user)
+
+
+class TestGenerateApiKey:
+    def test_generate_api_key(self, parent_api):
+        with _mock_set_key(PARENT_USER):
+            resp = parent_api.post("/users/me/api-key")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        api_key = body["data"]["api_key"]
+        assert api_key.startswith(f"{PARENT_USER.username}.")
+        parts = api_key.split(".", 1)
+        assert len(parts) == 2
+        assert len(parts[1]) > 10
+
+    def test_generate_api_key_message(self, parent_api):
+        with _mock_set_key(PARENT_USER):
+            resp = parent_api.post("/users/me/api-key")
+        body = resp.json()
+        assert "cannot be retrieved" in body["data"]["message"].lower()
+
+
+class TestAuthWithApiKey:
+    def test_auth_with_valid_key(self, client):
+        from backend.security import generate_api_key
+
+        full_key, key_hash = generate_api_key(PARENT_USER.username)
+        user_with_key = make_user("parent", PARENT_USER.username)
+        user_with_key.api_key_hash = key_hash
+
+        with _mock_get_user(user_with_key):
+            resp = client.post("/auth/api-key", json={"api_key": full_key})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "access_token" in data
+        assert data["token_type"] == "bearer"
+
+    def test_auth_with_invalid_key(self, client):
+        from backend.security import generate_api_key
+
+        _real_key, real_hash = generate_api_key(PARENT_USER.username)
+        user_with_key = make_user("parent", PARENT_USER.username)
+        user_with_key.api_key_hash = real_hash
+
+        with _mock_get_user(user_with_key):
+            resp = client.post("/auth/api-key", json={"api_key": f"{PARENT_USER.username}.wrongtoken"})
+        assert resp.status_code == 401
+
+    def test_auth_with_wrong_username(self, client):
+        with _mock_get_user(None):
+            resp = client.post("/auth/api-key", json={"api_key": "nonexistent.sometoken"})
+        assert resp.status_code == 401
+
+    def test_auth_with_no_dot(self, client):
+        resp = client.post("/auth/api-key", json={"api_key": "nodotinthiskey"})
+        assert resp.status_code == 401
+
+    def test_auth_no_key_stored(self, client):
+        user_no_key = make_user("parent", PARENT_USER.username)
+        user_no_key.api_key_hash = None
+
+        with _mock_get_user(user_no_key):
+            resp = client.post("/auth/api-key", json={"api_key": f"{PARENT_USER.username}.sometoken"})
+        assert resp.status_code == 401
+
+
+class TestRegenerateApiKey:
+    def test_regenerate_invalidates_old(self, parent_api, client):
+        from backend.security import generate_api_key
+
+        old_key, old_hash = generate_api_key(PARENT_USER.username)
+        new_key, new_hash = generate_api_key(PARENT_USER.username)
+
+        user_with_new = make_user("parent", PARENT_USER.username)
+        user_with_new.api_key_hash = new_hash
+
+        with _mock_get_user(user_with_new):
+            resp_old = client.post("/auth/api-key", json={"api_key": old_key})
+        assert resp_old.status_code == 401
+
+        with _mock_get_user(user_with_new):
+            resp_new = client.post("/auth/api-key", json={"api_key": new_key})
+        assert resp_new.status_code == 200
+        assert "access_token" in resp_new.json()

--- a/backend/tests/test_auth_enforcement.py
+++ b/backend/tests/test_auth_enforcement.py
@@ -1,0 +1,84 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from helpers import assert_error
+
+from backend.main import app
+
+
+def _unauth_client():
+    app.dependency_overrides.clear()
+    return TestClient(app)
+
+
+class TestAuthEnforcement:
+    def test_store_create_requires_auth(self):
+        c = _unauth_client()
+        r = c.post("/store/items/", json={"name": "Hack", "points_cost": 1})
+        assert_error(r, 401, "INVALID_CREDENTIALS")
+
+    def test_store_update_requires_auth(self):
+        c = _unauth_client()
+        r = c.put("/store/items/x", json={"name": "Hack", "points_cost": 1})
+        assert_error(r, 401, "INVALID_CREDENTIALS")
+
+    def test_store_delete_requires_auth(self):
+        c = _unauth_client()
+        r = c.delete("/store/items/x")
+        assert_error(r, 401, "INVALID_CREDENTIALS")
+
+    def test_award_points_requires_auth(self):
+        c = _unauth_client()
+        r = c.post("/kids/award-points/", json={"kid_username": "x", "points": 100})
+        assert_error(r, 401, "INVALID_CREDENTIALS")
+
+    def test_promote_requires_auth(self):
+        c = _unauth_client()
+        r = c.post("/users/promote-to-parent", json={"username": "x"})
+        assert_error(r, 401, "INVALID_CREDENTIALS")
+
+    def test_purchase_approve_requires_auth(self):
+        c = _unauth_client()
+        r = c.post("/parent/purchase-requests/approve", json={"log_id": "x"})
+        assert_error(r, 401, "INVALID_CREDENTIALS")
+
+    def test_purchase_reject_requires_auth(self):
+        c = _unauth_client()
+        r = c.post("/parent/purchase-requests/reject", json={"log_id": "x"})
+        assert_error(r, 401, "INVALID_CREDENTIALS")
+
+    def test_pending_purchases_requires_auth(self):
+        c = _unauth_client()
+        r = c.get("/parent/purchase-requests/pending")
+        assert_error(r, 401, "INVALID_CREDENTIALS")
+
+    def test_store_create_requires_parent(self, kid_api):
+        r = kid_api.post("/store/items/", json={"name": "Hack", "points_cost": 1})
+        assert_error(r, 403, "FORBIDDEN")
+
+    def test_award_points_requires_parent(self, kid_api):
+        r = kid_api.post("/kids/award-points/", json={"kid_username": "x", "points": 100})
+        assert_error(r, 403, "FORBIDDEN")
+
+    @patch("crud.create_store_item")
+    def test_store_create_works_for_parent(self, mock_create, parent_api):
+        from conftest import make_store_item
+
+        mock_create.return_value = make_store_item()
+        r = parent_api.post("/store/items/", json={"name": "OK", "points_cost": 10})
+        assert r.status_code == 201
+
+    @patch("crud.get_user_by_username")
+    @patch("crud.update_user_points")
+    def test_award_points_works_for_parent(self, mock_update, mock_get, parent_api):
+        from conftest import KID_USER
+
+        mock_get.return_value = KID_USER
+        mock_update.return_value = KID_USER
+        r = parent_api.post("/kids/award-points/", json={"kid_username": "testkid", "points": 10})
+        assert r.status_code == 200

--- a/backend/tests/test_bearded_dragon_endpoint.py
+++ b/backend/tests/test_bearded_dragon_endpoint.py
@@ -122,8 +122,9 @@ def test_bearded_dragon_purchases_filtering():
             # Verify response status
             assert response.status_code == 200
 
-            # Parse response data
-            data = response.json()
+            # Parse response data (unwrap envelope)
+            body = response.json()
+            data = body["data"]
 
             # Verify correct number of purchases returned (should be 4: 3 from kids + 1 pending)
             assert len(data) == 4, f"Expected 4 purchases, got {len(data)}"

--- a/backend/tests/test_envelope.py
+++ b/backend/tests/test_envelope.py
@@ -1,0 +1,180 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from unittest.mock import patch
+
+from conftest import (
+    KID_USER,
+    PARENT_USER,
+    make_chore,
+    make_chore_log,
+    make_purchase_log,
+    make_store_item,
+)
+from helpers import assert_envelope, assert_envelope_list, assert_error
+
+
+class TestEnvelopeOnSuccess:
+    def test_health_not_wrapped(self, api):
+        r = api.get("/health")
+        body = r.json()
+        assert body == {"status": "healthy"}
+        assert "success" not in body
+
+    def test_root_not_wrapped(self, api):
+        r = api.get("/")
+        body = r.json()
+        assert "message" in body
+        assert "success" not in body
+
+    @patch("crud.get_all_active_chores")
+    def test_list_endpoint_wrapped(self, mock_chores, parent_api):
+        chore = make_chore()
+        mock_chores.return_value = [chore]
+        r = parent_api.get("/chores/")
+        data = assert_envelope_list(r, 200)
+        assert len(data) == 1
+        assert data[0]["name"] == "Test Chore"
+
+    @patch("crud.get_all_active_chores")
+    def test_list_meta_has_count(self, mock_chores, parent_api):
+        mock_chores.return_value = [make_chore(), make_chore()]
+        r = parent_api.get("/chores/")
+        body = r.json()
+        assert body["meta"]["count"] == 2
+
+    @patch("crud.get_store_item_by_id")
+    def test_single_item_wrapped(self, mock_get, parent_api):
+        item = make_store_item()
+        mock_get.return_value = item
+        r = parent_api.get(f"/store/items/{item.id}")
+        data = assert_envelope(r, 200)
+        assert data["name"] == "Test Item"
+
+    @patch("crud.create_store_item")
+    def test_create_wrapped_with_201(self, mock_create, parent_api):
+        item = make_store_item()
+        mock_create.return_value = item
+        r = parent_api.post("/store/items/", json={"name": "New", "points_cost": 10})
+        data = assert_envelope(r, 201)
+        assert data["name"] == item.name
+
+    @patch("crud.delete_store_item")
+    def test_delete_returns_success_envelope(self, mock_del, parent_api):
+        mock_del.return_value = True
+        r = parent_api.delete("/store/items/test-id")
+        data = assert_envelope(r, 200)
+        assert data is None
+
+
+class TestEnvelopeOnError:
+    def test_404_wrapped(self, parent_api):
+        with patch("crud.get_store_item_by_id", return_value=None):
+            r = parent_api.get("/store/items/nonexistent")
+            err = assert_error(r, 404, "NOT_FOUND")
+            assert "not found" in err["message"].lower()
+
+    def test_401_wrapped(self):
+        from fastapi.testclient import TestClient
+
+        from backend.main import app
+
+        app.dependency_overrides.clear()
+        with TestClient(app) as unauth:
+            r = unauth.get("/users/me/")
+            assert_error(r, 401, "INVALID_CREDENTIALS")
+        app.dependency_overrides.clear()
+
+    def test_validation_error_wrapped(self, parent_api):
+        r = parent_api.post("/store/items/", json={"name": "Bad", "points_cost": -1})
+        err = assert_error(r, 422, "VALIDATION_ERROR")
+        assert "fields" in err.get("details", {})
+
+    @patch("crud.get_user_by_username")
+    def test_400_already_exists(self, mock_get, api):
+        from backend.models import User, UserRole
+
+        mock_get.return_value = User(id="x", username="exists", role=UserRole.KID, hashed_password="h", points=0)
+        r = api.post("/users/", json={"username": "exists", "password": "pass1234"})
+        assert_error(r, 400, "ALREADY_EXISTS")
+
+    @patch("crud.get_store_item_by_id")
+    def test_400_insufficient_points(self, mock_item, kid_api):
+        item = make_store_item(points_cost=99999)
+        mock_item.return_value = item
+        r = kid_api.post("/kids/redeem-item/", json={"item_id": item.id})
+        assert_error(r, 400, "INSUFFICIENT_POINTS")
+
+
+class TestEnvelopeListEndpoints:
+    @patch("crud.get_store_items")
+    def test_store_items_list(self, mock_items, parent_api):
+        mock_items.return_value = [make_store_item(), make_store_item()]
+        r = parent_api.get("/store/items/")
+        data = assert_envelope_list(r, 200, min_count=2)
+        assert all("name" in item for item in data)
+
+    @patch("crud.get_all_users")
+    def test_leaderboard(self, mock_users, parent_api):
+        mock_users.return_value = [PARENT_USER, KID_USER]
+        r = parent_api.get("/leaderboard")
+        assert_envelope_list(r, 200, min_count=2)
+
+    @patch("crud.get_chore_logs_by_kid_id")
+    def test_chore_history(self, mock_logs, kid_api):
+        mock_logs.return_value = [make_chore_log()]
+        r = kid_api.get("/chores/history/me")
+        assert_envelope_list(r, 200, min_count=1)
+
+    @patch("crud.get_purchase_logs_by_user_id")
+    def test_purchase_history(self, mock_logs, kid_api):
+        mock_logs.return_value = [make_purchase_log()]
+        r = kid_api.get("/users/me/purchase-history")
+        assert_envelope_list(r, 200, min_count=1)
+
+    @patch("crud.get_chore_logs_by_status_for_parent")
+    def test_pending_chore_submissions(self, mock_logs, parent_api):
+        mock_logs.return_value = []
+        r = parent_api.get("/parent/chore-submissions/pending")
+        assert_envelope_list(r, 200)
+
+    @patch("crud.get_purchase_logs_by_status")
+    def test_pending_purchases(self, mock_logs, parent_api):
+        mock_logs.return_value = []
+        r = parent_api.get("/parent/purchase-requests/pending")
+        assert_envelope_list(r, 200)
+
+    @patch("crud.get_requests_by_status")
+    def test_pending_requests(self, mock_reqs, parent_api):
+        mock_reqs.return_value = []
+        r = parent_api.get("/parent/requests/pending/")
+        assert_envelope_list(r, 200)
+
+    @patch("crud.get_assignments_by_kid_id")
+    def test_kid_assignments(self, mock_assigns, kid_api):
+        mock_assigns.return_value = []
+        r = kid_api.get("/kids/my-assignments/")
+        assert_envelope_list(r, 200)
+
+    @patch("crud.get_active_pets")
+    def test_pets_list(self, mock_pets, parent_api):
+        mock_pets.return_value = []
+        r = parent_api.get("/pets/")
+        assert_envelope_list(r, 200)
+
+
+class TestEnvelopeSingleEndpoints:
+    @patch("crud.get_chore_by_id")
+    def test_get_chore(self, mock_get, parent_api):
+        chore = make_chore()
+        mock_get.return_value = chore
+        r = parent_api.get(f"/chores/{chore.id}")
+        data = assert_envelope(r, 200)
+        assert data["id"] == chore.id
+
+    def test_get_me(self, parent_api):
+        r = parent_api.get("/users/me/")
+        data = assert_envelope(r, 200)
+        assert data["username"] == PARENT_USER.username

--- a/backend/tests/test_pagination.py
+++ b/backend/tests/test_pagination.py
@@ -5,8 +5,6 @@ sys.path.insert(0, os.path.dirname(__file__))
 
 from unittest.mock import patch
 
-from helpers import assert_envelope
-
 
 class TestPagination:
     @patch("crud.get_store_items")

--- a/backend/tests/test_pagination.py
+++ b/backend/tests/test_pagination.py
@@ -1,0 +1,94 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+from unittest.mock import patch
+
+from helpers import assert_envelope
+
+
+class TestPagination:
+    @patch("crud.get_store_items")
+    def test_store_items_default_pagination(self, mock_get, api):
+        from conftest import make_store_item
+
+        items = [make_store_item(name=f"Item {i}") for i in range(5)]
+        mock_get.return_value = items
+        r = api.get("/store/items/")
+        body = r.json()
+        assert body["success"] is True
+        assert body["meta"]["total"] == 5
+        assert body["meta"]["count"] == 5
+        assert body["meta"]["limit"] == 100
+        assert body["meta"]["offset"] == 0
+
+    @patch("crud.get_store_items")
+    def test_store_items_limit_offset(self, mock_get, api):
+        from conftest import make_store_item
+
+        items = [make_store_item(name=f"Item {i}") for i in range(10)]
+        mock_get.return_value = items
+        r = api.get("/store/items/?limit=3&offset=2")
+        body = r.json()
+        assert body["meta"]["total"] == 10
+        assert body["meta"]["count"] == 3
+        assert body["meta"]["limit"] == 3
+        assert body["meta"]["offset"] == 2
+
+    @patch("crud.get_store_items")
+    def test_store_items_offset_past_end(self, mock_get, api):
+        from conftest import make_store_item
+
+        items = [make_store_item(name=f"Item {i}") for i in range(3)]
+        mock_get.return_value = items
+        r = api.get("/store/items/?offset=10")
+        body = r.json()
+        assert body["meta"]["total"] == 3
+        assert body["meta"]["count"] == 0
+        assert body["data"] == []
+
+
+class TestFiltering:
+    @patch("crud.get_all_active_chores")
+    def test_chores_default_active_only(self, mock_get, api):
+        from conftest import make_chore
+
+        mock_get.return_value = [make_chore()]
+        r = api.get("/chores/")
+        body = r.json()
+        assert body["success"] is True
+        mock_get.assert_called_once()
+
+    @patch("crud.get_all_chores_scan_fallback")
+    def test_chores_include_inactive(self, mock_get, api):
+        from conftest import make_chore
+
+        mock_get.return_value = [make_chore()]
+        r = api.get("/chores/?include_inactive=true")
+        body = r.json()
+        assert body["success"] is True
+        mock_get.assert_called_once()
+
+    @patch("crud.get_assignments_by_kid_id")
+    def test_assignments_filter_by_status(self, mock_get, kid_api):
+        from conftest import make_assignment
+
+        assigned = make_assignment(assignment_status="assigned")
+        submitted = make_assignment(assignment_status="submitted")
+        mock_get.return_value = [assigned, submitted]
+        r = kid_api.get("/kids/my-assignments/?status=assigned")
+        body = r.json()
+        assert body["meta"]["total"] == 1
+        assert body["meta"]["count"] == 1
+
+    @patch("crud.get_all_users")
+    def test_users_filter_by_role(self, mock_get, parent_api):
+        from conftest import make_user
+
+        parent = make_user("parent", "p1")
+        kid = make_user("kid", "k1")
+        mock_get.return_value = [parent, kid]
+        r = parent_api.get("/users/?role=kid")
+        body = r.json()
+        assert body["meta"]["count"] == 1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -89,6 +89,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
       "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -691,6 +692,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.27.1.tgz",
       "integrity": "sha512-p9OkPbZ5G7UT1MofwYFigGebnrzGJacoBSQM0/6bi/PUMVE+qlWDD/OalvQKbwgQzU6dl0xAv6r4X7Jme0RYxA==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -1499,6 +1501,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
       "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.1",
         "@babel/helper-module-imports": "^7.27.1",
@@ -2861,6 +2864,7 @@
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.0.1.tgz",
       "integrity": "sha512-4ezaxKjChSPtawamQ3KrJq+x506uTouXlL0Z5fP+t105KnyxMrAJUENhbh2ivD4pq9Zh1BFiD9IWzyu3IXFR8w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.26.28",
         "clsx": "^2.1.1",
@@ -2908,6 +2912,7 @@
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.0.1.tgz",
       "integrity": "sha512-GvLdM4Ro3QcDyIgqrdXsUZmeeKye2TNL/k3mEr9JhM5KacHQjr83JPp0u9eLobn7kiyBqpLTYmVYAbmjJdCxHw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -3430,6 +3435,7 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -3794,6 +3800,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
       "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3803,6 +3810,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
       "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3895,6 +3903,7 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
       "integrity": "sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.62.0",
@@ -3946,6 +3955,7 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -4285,6 +4295,7 @@
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4363,6 +4374,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5210,6 +5222,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001716",
         "electron-to-chromium": "^1.5.149",
@@ -6942,6 +6955,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9540,6 +9554,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -11712,6 +11727,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -12828,6 +12844,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13166,6 +13183,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13290,6 +13308,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -13322,6 +13341,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13879,6 +13899,7 @@
       "version": "2.79.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -14106,6 +14127,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15696,6 +15718,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16075,6 +16098,7 @@
       "version": "5.99.9",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
       "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -16143,6 +16167,7 @@
       "version": "4.15.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.2.tgz",
       "integrity": "sha512-0XavAZbNJ5sDrCbkpWL8mia0o5WPOd2YGtxrEiZkBK9FjLppIUK2TgxK6qGD2P3hUXTJNNPVibrerKcx5WkR1g==",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -16530,6 +16555,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -26,6 +26,24 @@ apiClient.interceptors.request.use(
   }
 );
 
+// Unwrap API envelope: {success, data, meta, error} -> data
+apiClient.interceptors.response.use(
+  (response) => {
+    if (response.data && typeof response.data === 'object' && 'success' in response.data) {
+      response.data = response.data.data;
+    }
+    return response;
+  },
+  (error) => {
+    if (error.response?.data && typeof error.response.data === 'object' && 'error' in error.response.data) {
+      const apiError = error.response.data.error;
+      error.message = apiError?.message || error.message;
+      error.code = apiError?.code;
+    }
+    return Promise.reject(error);
+  }
+);
+
 // User types (can be expanded or moved to a dedicated types file)
 export interface User {
   id: string;

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,8 +1,13 @@
+import json
+import logging
 import os
 from typing import Optional
 
 import httpx
 from fastmcp import FastMCP
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+logger = logging.getLogger("kids-rewards-mcp")
 
 BASE_URL = os.environ.get("KIDS_REWARDS_API_URL", "http://localhost:3000")
 
@@ -15,6 +20,7 @@ mcp = FastMCP(
     ),
 )
 
+_client = httpx.AsyncClient(base_url=BASE_URL, timeout=30)
 _token: str | None = None
 
 
@@ -24,489 +30,684 @@ def _headers() -> dict:
     return {}
 
 
-def _url(path: str) -> str:
-    return f"{BASE_URL}{path}"
+def _fmt(data) -> str:
+    return json.dumps(data, indent=2, default=str)
 
 
-def _get(path: str, params: dict | None = None) -> dict:
-    r = httpx.get(_url(path), headers=_headers(), params=params, timeout=30)
-    return r.json()
+async def _get(path: str, params: dict | None = None) -> str:
+    try:
+        r = await _client.get(path, headers=_headers(), params=params)
+        logger.info("GET %s -> %d", path, r.status_code)
+        return _fmt(r.json())
+    except httpx.HTTPError as exc:
+        logger.error("GET %s failed: %s", path, exc)
+        return _fmt({"success": False, "error": {"code": "CONNECTION_ERROR", "message": str(exc)}})
 
 
-def _post(path: str, json: dict | None = None, data: dict | None = None) -> dict:
-    r = httpx.post(_url(path), headers=_headers(), json=json, data=data, timeout=30)
-    return r.json()
+async def _post(path: str, json_data: dict | None = None, data: dict | None = None) -> str:
+    try:
+        r = await _client.post(path, headers=_headers(), json=json_data, data=data)
+        logger.info("POST %s -> %d", path, r.status_code)
+        return _fmt(r.json())
+    except httpx.HTTPError as exc:
+        logger.error("POST %s failed: %s", path, exc)
+        return _fmt({"success": False, "error": {"code": "CONNECTION_ERROR", "message": str(exc)}})
 
 
-def _put(path: str, json: dict) -> dict:
-    r = httpx.put(_url(path), headers=_headers(), json=json, timeout=30)
-    return r.json()
+async def _put(path: str, json_data: dict) -> str:
+    try:
+        r = await _client.put(path, headers=_headers(), json=json_data)
+        logger.info("PUT %s -> %d", path, r.status_code)
+        return _fmt(r.json())
+    except httpx.HTTPError as exc:
+        logger.error("PUT %s failed: %s", path, exc)
+        return _fmt({"success": False, "error": {"code": "CONNECTION_ERROR", "message": str(exc)}})
 
 
-def _delete(path: str) -> dict:
-    r = httpx.delete(_url(path), headers=_headers(), timeout=30)
-    if r.status_code == 200:
-        return r.json()
-    return {"success": True, "data": None}
+async def _delete(path: str) -> str:
+    try:
+        r = await _client.delete(path, headers=_headers())
+        logger.info("DELETE %s -> %d", path, r.status_code)
+        if r.status_code == 200:
+            return _fmt(r.json())
+        return _fmt({"success": True, "data": None})
+    except httpx.HTTPError as exc:
+        logger.error("DELETE %s failed: %s", path, exc)
+        return _fmt({"success": False, "error": {"code": "CONNECTION_ERROR", "message": str(exc)}})
 
 
 # ── Auth & Users ──────────────────────────────────────────────
 
 
-@mcp.tool
-def login(username: str, password: str) -> dict:
-    """Authenticate and store token. Must be called before other tools."""
+@mcp.tool()
+async def login(username: str, password: str) -> str:
+    """Authenticate and store a session token. Must be called before using any other tool.
+
+    Args:
+        username: The user's login name.
+        password: The user's password.
+    """
     global _token
-    r = httpx.post(
-        _url("/token"),
-        data={"username": username, "password": password},
-        timeout=30,
-    )
-    result = r.json()
-    if "access_token" in result:
-        _token = result["access_token"]
-        return {"success": True, "message": f"Logged in as {username}"}
-    return {"success": False, "error": result}
+    try:
+        r = await _client.post("/token", data={"username": username, "password": password})
+        result = r.json()
+        if "access_token" in result:
+            _token = result["access_token"]
+            logger.info("Login successful for %s", username)
+            return _fmt({"success": True, "message": f"Logged in as {username}"})
+        logger.warning("Login failed for %s", username)
+        return _fmt({"success": False, "error": result})
+    except httpx.HTTPError as exc:
+        logger.error("Login failed: %s", exc)
+        return _fmt({"success": False, "error": {"code": "CONNECTION_ERROR", "message": str(exc)}})
 
 
-@mcp.tool
-def register_user(username: str, password: str, role: str = "kid") -> dict:
-    """Register a new user account. Role: 'kid' or 'parent'."""
-    return _post("/users/", json={"username": username, "password": password, "role": role})
+@mcp.tool()
+async def register_user(username: str, password: str, role: str = "kid") -> str:
+    """Register a new user account.
+
+    Args:
+        username: Desired username for the new account.
+        password: Password for the new account.
+        role: User role - 'kid' or 'parent'.
+    """
+    return await _post("/users/", json_data={"username": username, "password": password, "role": role})
 
 
-@mcp.tool
-def get_current_user() -> dict:
-    """Get the currently authenticated user's profile."""
-    return _get("/users/me/")
+@mcp.tool()
+async def get_current_user() -> str:
+    """Get the currently authenticated user's profile including points and role."""
+    return await _get("/users/me/")
 
 
-@mcp.tool
-def list_users(role: Optional[str] = None, limit: int = 100, offset: int = 0) -> dict:
-    """List all users. Parent-only. Optional filter by role ('kid' or 'parent')."""
+@mcp.tool()
+async def list_users(role: Optional[str] = None, limit: int = 100, offset: int = 0) -> str:
+    """List all users. Parent-only.
+
+    Args:
+        role: Filter by role - 'kid' or 'parent'. Omit for all users.
+        limit: Maximum number of results (1-500).
+        offset: Number of results to skip for pagination.
+    """
     params = {"limit": limit, "offset": offset}
     if role:
         params["role"] = role
-    return _get("/users/", params=params)
+    return await _get("/users/", params=params)
 
 
-@mcp.tool
-def promote_to_parent(username: str) -> dict:
-    """Promote a kid user to parent role. Parent-only."""
-    return _post("/users/promote-to-parent", json={"username": username})
+@mcp.tool()
+async def promote_to_parent(username: str) -> str:
+    """Promote a kid user to parent role. Parent-only.
+
+    Args:
+        username: Username of the kid to promote.
+    """
+    return await _post("/users/promote-to-parent", json_data={"username": username})
 
 
-@mcp.tool
-def award_points(kid_username: str, points: int) -> dict:
-    """Award bonus points to a kid. Parent-only."""
-    return _post("/kids/award-points/", json={"kid_username": kid_username, "points": points})
+@mcp.tool()
+async def award_points(kid_username: str, points: int) -> str:
+    """Award bonus points to a kid. Parent-only.
+
+    Args:
+        kid_username: Username of the kid to award points to.
+        points: Number of points to award.
+    """
+    return await _post("/kids/award-points/", json_data={"kid_username": kid_username, "points": points})
 
 
-@mcp.tool
-def get_leaderboard() -> dict:
-    """Get all users sorted by points (highest first)."""
-    return _get("/leaderboard")
+@mcp.tool()
+async def get_leaderboard() -> str:
+    """Get all users sorted by points, highest first."""
+    return await _get("/leaderboard")
 
 
 # ── Store ─────────────────────────────────────────────────────
 
 
-@mcp.tool
-def list_store_items(
+@mcp.tool()
+async def list_store_items(
     sort: Optional[str] = None,
     order: str = "asc",
     limit: int = 100,
     offset: int = 0,
-) -> dict:
-    """List store items. Sort by 'points_cost' or 'name'. Order: 'asc' or 'desc'."""
+) -> str:
+    """List available store reward items.
+
+    Args:
+        sort: Sort field - 'points_cost' or 'name'. Omit for default order.
+        order: Sort direction - 'asc' or 'desc'.
+        limit: Maximum number of results (1-500).
+        offset: Number of results to skip for pagination.
+    """
     params = {"limit": limit, "offset": offset, "order": order}
     if sort:
         params["sort"] = sort
-    return _get("/store/items/", params=params)
+    return await _get("/store/items/", params=params)
 
 
-@mcp.tool
-def get_store_item(item_id: str) -> dict:
-    """Get a specific store item by ID."""
-    return _get(f"/store/items/{item_id}")
+@mcp.tool()
+async def get_store_item(item_id: str) -> str:
+    """Get a specific store item by its ID.
+
+    Args:
+        item_id: The unique identifier of the store item.
+    """
+    return await _get(f"/store/items/{item_id}")
 
 
-@mcp.tool
-def create_store_item(name: str, points_cost: int, description: str = "") -> dict:
-    """Create a new store reward item. Parent-only."""
-    return _post("/store/items/", json={"name": name, "points_cost": points_cost, "description": description})
+@mcp.tool()
+async def create_store_item(name: str, points_cost: int, description: str = "") -> str:
+    """Create a new store reward item. Parent-only.
+
+    Args:
+        name: Display name for the reward item.
+        points_cost: Number of points required to purchase.
+        description: Optional longer description of the item.
+    """
+    return await _post("/store/items/", json_data={"name": name, "points_cost": points_cost, "description": description})
 
 
-@mcp.tool
-def update_store_item(item_id: str, name: str, points_cost: int, description: str = "") -> dict:
-    """Update an existing store item. Parent-only."""
-    return _put(f"/store/items/{item_id}", json={"name": name, "points_cost": points_cost, "description": description})
+@mcp.tool()
+async def update_store_item(item_id: str, name: str, points_cost: int, description: str = "") -> str:
+    """Update an existing store item. Parent-only.
+
+    Args:
+        item_id: ID of the store item to update.
+        name: New display name.
+        points_cost: New points cost.
+        description: New description.
+    """
+    return await _put(
+        f"/store/items/{item_id}",
+        json_data={"name": name, "points_cost": points_cost, "description": description},
+    )
 
 
-@mcp.tool
-def delete_store_item(item_id: str) -> dict:
-    """Delete a store item. Parent-only."""
-    return _delete(f"/store/items/{item_id}")
+@mcp.tool()
+async def delete_store_item(item_id: str) -> str:
+    """Delete a store item permanently. Parent-only.
+
+    Args:
+        item_id: ID of the store item to delete.
+    """
+    return await _delete(f"/store/items/{item_id}")
 
 
-@mcp.tool
-def purchase_store_item(item_id: str) -> dict:
-    """Purchase a store item using points. Kid action."""
-    return _post("/store/items/purchase", json={"item_id": item_id})
+@mcp.tool()
+async def purchase_store_item(item_id: str) -> str:
+    """Purchase a store item using the current kid's points.
+
+    Args:
+        item_id: ID of the store item to purchase.
+    """
+    return await _post("/store/items/purchase", json_data={"item_id": item_id})
 
 
 # ── Chores ────────────────────────────────────────────────────
 
 
-@mcp.tool
-def list_chores(include_inactive: bool = False, limit: int = 100, offset: int = 0) -> dict:
-    """List available chores. Set include_inactive=True to see all."""
+@mcp.tool()
+async def list_chores(include_inactive: bool = False, limit: int = 100, offset: int = 0) -> str:
+    """List chores. By default only active chores are returned.
+
+    Args:
+        include_inactive: Set True to include deactivated chores.
+        limit: Maximum number of results (1-500).
+        offset: Number of results to skip for pagination.
+    """
     params = {"limit": limit, "offset": offset}
     if include_inactive:
         params["include_inactive"] = "true"
-    return _get("/chores/", params=params)
+    return await _get("/chores/", params=params)
 
 
-@mcp.tool
-def get_chore(chore_id: str) -> dict:
-    """Get a specific chore by ID."""
-    return _get(f"/chores/{chore_id}")
+@mcp.tool()
+async def get_chore(chore_id: str) -> str:
+    """Get details of a specific chore.
+
+    Args:
+        chore_id: The unique identifier of the chore.
+    """
+    return await _get(f"/chores/{chore_id}")
 
 
-@mcp.tool
-def create_chore(
-    name: str,
-    description: str,
-    points_value: int,
-    is_active: bool = True,
-) -> dict:
-    """Create a new chore. Parent-only."""
-    return _post(
+@mcp.tool()
+async def create_chore(name: str, description: str, points_value: int, is_active: bool = True) -> str:
+    """Create a new chore definition. Parent-only.
+
+    Args:
+        name: Short name for the chore.
+        description: What the chore involves.
+        points_value: Points awarded upon approval.
+        is_active: Whether the chore is immediately available.
+    """
+    return await _post(
         "/chores/",
-        json={
-            "name": name,
-            "description": description,
-            "points_value": points_value,
-            "is_active": is_active,
-        },
+        json_data={"name": name, "description": description, "points_value": points_value, "is_active": is_active},
     )
 
 
-@mcp.tool
-def update_chore(
-    chore_id: str,
-    name: str,
-    description: str,
-    points_value: int,
-    is_active: bool = True,
-) -> dict:
-    """Update an existing chore. Parent-only."""
-    return _put(
+@mcp.tool()
+async def update_chore(
+    chore_id: str, name: str, description: str, points_value: int, is_active: bool = True
+) -> str:
+    """Update an existing chore definition. Parent-only.
+
+    Args:
+        chore_id: ID of the chore to update.
+        name: Updated chore name.
+        description: Updated description.
+        points_value: Updated points value.
+        is_active: Whether the chore should be active.
+    """
+    return await _put(
         f"/chores/{chore_id}",
-        json={
-            "name": name,
-            "description": description,
-            "points_value": points_value,
-            "is_active": is_active,
-        },
+        json_data={"name": name, "description": description, "points_value": points_value, "is_active": is_active},
     )
 
 
-@mcp.tool
-def deactivate_chore(chore_id: str) -> dict:
-    """Deactivate a chore. Parent-only."""
-    return _post(f"/chores/{chore_id}/deactivate")
+@mcp.tool()
+async def deactivate_chore(chore_id: str) -> str:
+    """Deactivate a chore so it no longer appears in active lists. Parent-only.
+
+    Args:
+        chore_id: ID of the chore to deactivate.
+    """
+    return await _post(f"/chores/{chore_id}/deactivate")
 
 
-@mcp.tool
-def delete_chore(chore_id: str) -> dict:
-    """Delete a chore. Parent-only."""
-    return _delete(f"/chores/{chore_id}")
+@mcp.tool()
+async def delete_chore(chore_id: str) -> str:
+    """Permanently delete a chore. Parent-only.
+
+    Args:
+        chore_id: ID of the chore to delete.
+    """
+    return await _delete(f"/chores/{chore_id}")
 
 
-@mcp.tool
-def submit_chore(chore_id: str, effort_minutes: int = 0) -> dict:
-    """Submit a chore completion. Kid action. effort_minutes tracks time spent."""
-    return _post(f"/chores/{chore_id}/submit", json={"effort_minutes": effort_minutes})
+@mcp.tool()
+async def submit_chore(chore_id: str, effort_minutes: int = 0) -> str:
+    """Submit a chore as completed for parent approval. Kid action.
+
+    Args:
+        chore_id: ID of the chore being submitted.
+        effort_minutes: Time spent on the chore in minutes (0-240). Earns effort points.
+    """
+    return await _post(f"/chores/{chore_id}/submit", json_data={"effort_minutes": effort_minutes})
 
 
 # ── Chore History & Stats ─────────────────────────────────────
 
 
-@mcp.tool
-def get_my_chore_history(
-    status: Optional[str] = None,
-    limit: int = 100,
-    offset: int = 0,
-) -> dict:
-    """Get the current kid's chore submission history. Filter by status."""
+@mcp.tool()
+async def get_my_chore_history(status: Optional[str] = None, limit: int = 100, offset: int = 0) -> str:
+    """Get the current kid's chore submission history.
+
+    Args:
+        status: Filter by status - 'pending_approval', 'approved', 'rejected'.
+        limit: Maximum number of results (1-500).
+        offset: Number of results to skip for pagination.
+    """
     params = {"limit": limit, "offset": offset}
     if status:
         params["status"] = status
-    return _get("/chores/history/me", params=params)
+    return await _get("/chores/history/me", params=params)
 
 
-@mcp.tool
-def get_my_chore_stats() -> dict:
-    """Get aggregated chore statistics for the current kid."""
-    return _get("/chores/history/me/stats")
+@mcp.tool()
+async def get_my_chore_stats() -> str:
+    """Get aggregated chore statistics for the current kid, including totals, effort, and streaks."""
+    return await _get("/chores/history/me/stats")
 
 
-@mcp.tool
-def get_my_streak() -> dict:
-    """Get the current kid's streak information."""
-    return _get("/kids/streak/")
+@mcp.tool()
+async def get_my_streak() -> str:
+    """Get the current kid's streak data including current streak days and bonus milestones."""
+    return await _get("/kids/streak/")
 
 
 # ── Chore Submissions (Parent) ───────────────────────────────
 
 
-@mcp.tool
-def get_pending_chore_submissions() -> dict:
-    """Get all pending chore submissions awaiting parent approval."""
-    return _get("/parent/chore-submissions/pending")
+@mcp.tool()
+async def get_pending_chore_submissions() -> str:
+    """Get all chore submissions awaiting parent approval. Parent-only."""
+    return await _get("/parent/chore-submissions/pending")
 
 
-@mcp.tool
-def approve_chore_submission(log_id: str) -> dict:
-    """Approve a kid's chore submission. Parent-only."""
-    return _post("/parent/chore-submissions/approve", json={"log_id": log_id})
+@mcp.tool()
+async def approve_chore_submission(log_id: str) -> str:
+    """Approve a kid's chore submission and award points. Parent-only.
+
+    Args:
+        log_id: ID of the chore log entry to approve.
+    """
+    return await _post("/parent/chore-submissions/approve", json_data={"log_id": log_id})
 
 
-@mcp.tool
-def reject_chore_submission(log_id: str, reason: str = "") -> dict:
-    """Reject a kid's chore submission. Parent-only."""
-    return _post("/parent/chore-submissions/reject", json={"log_id": log_id, "reason": reason})
+@mcp.tool()
+async def reject_chore_submission(log_id: str, reason: str = "") -> str:
+    """Reject a kid's chore submission. Parent-only.
+
+    Args:
+        log_id: ID of the chore log entry to reject.
+        reason: Optional explanation for the rejection.
+    """
+    return await _post("/parent/chore-submissions/reject", json_data={"log_id": log_id, "reason": reason})
 
 
 # ── Chore Assignments ─────────────────────────────────────────
 
 
-@mcp.tool
-def create_assignment(
-    chore_id: str,
-    kid_username: str,
-    due_date: Optional[str] = None,
-    notes: str = "",
-) -> dict:
-    """Assign a chore to a kid. Parent-only. due_date format: YYYY-MM-DD."""
+@mcp.tool()
+async def create_assignment(
+    chore_id: str, kid_username: str, due_date: Optional[str] = None, notes: str = ""
+) -> str:
+    """Assign a specific chore to a kid. Parent-only.
+
+    Args:
+        chore_id: ID of the chore to assign.
+        kid_username: Username of the kid to assign it to.
+        due_date: Optional deadline in YYYY-MM-DD format.
+        notes: Optional instructions or context.
+    """
     payload = {"chore_id": chore_id, "kid_username": kid_username, "notes": notes}
     if due_date:
         payload["due_date"] = due_date
-    return _post("/parent/chore-assignments/", json=payload)
+    return await _post("/parent/chore-assignments/", json_data=payload)
 
 
-@mcp.tool
-def get_my_assignments(
-    status: Optional[str] = None,
-    limit: int = 100,
-    offset: int = 0,
-) -> dict:
-    """Get the current kid's assigned chores. Filter by status."""
+@mcp.tool()
+async def get_my_assignments(status: Optional[str] = None, limit: int = 100, offset: int = 0) -> str:
+    """Get the current kid's assigned chores.
+
+    Args:
+        status: Filter by status - 'assigned', 'submitted', 'approved', 'rejected', 'overdue'.
+        limit: Maximum number of results (1-500).
+        offset: Number of results to skip for pagination.
+    """
     params = {"limit": limit, "offset": offset}
     if status:
         params["status"] = status
-    return _get("/kids/my-assignments/", params=params)
+    return await _get("/kids/my-assignments/", params=params)
 
 
-@mcp.tool
-def submit_assignment(assignment_id: str, notes: str = "") -> dict:
-    """Submit an assignment completion. Kid action."""
-    return _post(
-        f"/kids/my-assignments/{assignment_id}/submit",
-        json={"notes": notes},
-    )
+@mcp.tool()
+async def submit_assignment(assignment_id: str, notes: str = "") -> str:
+    """Submit an assigned chore as completed. Kid action.
+
+    Args:
+        assignment_id: ID of the assignment to submit.
+        notes: Optional notes about the completion.
+    """
+    return await _post(f"/kids/my-assignments/{assignment_id}/submit", json_data={"notes": notes})
 
 
-@mcp.tool
-def get_pending_assignment_submissions() -> dict:
-    """Get pending assignment submissions. Parent-only."""
-    return _get("/parent/assignment-submissions/pending")
+@mcp.tool()
+async def get_pending_assignment_submissions() -> str:
+    """Get all assignment submissions awaiting parent approval. Parent-only."""
+    return await _get("/parent/assignment-submissions/pending")
 
 
-@mcp.tool
-def approve_assignment(assignment_id: str) -> dict:
-    """Approve a kid's assignment submission. Parent-only."""
-    return _post("/parent/assignment-submissions/approve", json={"assignment_id": assignment_id})
+@mcp.tool()
+async def approve_assignment(assignment_id: str) -> str:
+    """Approve a kid's assignment submission. Parent-only.
+
+    Args:
+        assignment_id: ID of the assignment to approve.
+    """
+    return await _post("/parent/assignment-submissions/approve", json_data={"assignment_id": assignment_id})
 
 
-@mcp.tool
-def reject_assignment(assignment_id: str, reason: str = "") -> dict:
-    """Reject a kid's assignment submission. Parent-only."""
-    return _post(
+@mcp.tool()
+async def reject_assignment(assignment_id: str, reason: str = "") -> str:
+    """Reject a kid's assignment submission. Parent-only.
+
+    Args:
+        assignment_id: ID of the assignment to reject.
+        reason: Optional explanation for the rejection.
+    """
+    return await _post(
         "/parent/assignment-submissions/reject",
-        json={"assignment_id": assignment_id, "reason": reason},
+        json_data={"assignment_id": assignment_id, "reason": reason},
     )
 
 
-@mcp.tool
-def list_parent_assignments() -> dict:
+@mcp.tool()
+async def list_parent_assignments() -> str:
     """List all chore assignments created by the current parent."""
-    return _get("/parent/chore-assignments/")
+    return await _get("/parent/chore-assignments/")
 
 
 # ── Purchases ─────────────────────────────────────────────────
 
 
-@mcp.tool
-def get_my_purchase_history(
-    status: Optional[str] = None,
-    limit: int = 100,
-    offset: int = 0,
-) -> dict:
-    """Get the current user's purchase history. Filter by status."""
+@mcp.tool()
+async def get_my_purchase_history(status: Optional[str] = None, limit: int = 100, offset: int = 0) -> str:
+    """Get the current user's purchase history.
+
+    Args:
+        status: Filter by status - 'pending', 'approved', 'rejected'.
+        limit: Maximum number of results (1-500).
+        offset: Number of results to skip for pagination.
+    """
     params = {"limit": limit, "offset": offset}
     if status:
         params["status"] = status
-    return _get("/users/me/purchase-history", params=params)
+    return await _get("/users/me/purchase-history", params=params)
 
 
-@mcp.tool
-def get_pending_purchases() -> dict:
-    """Get all pending purchase requests. Parent-only."""
-    return _get("/parent/purchase-requests/pending")
+@mcp.tool()
+async def get_pending_purchases() -> str:
+    """Get all pending purchase requests awaiting parent approval. Parent-only."""
+    return await _get("/parent/purchase-requests/pending")
 
 
-@mcp.tool
-def approve_purchase(log_id: str) -> dict:
-    """Approve a purchase request. Parent-only."""
-    return _post("/parent/purchase-requests/approve", json={"log_id": log_id})
+@mcp.tool()
+async def approve_purchase(log_id: str) -> str:
+    """Approve a purchase request. Parent-only.
+
+    Args:
+        log_id: ID of the purchase log entry to approve.
+    """
+    return await _post("/parent/purchase-requests/approve", json_data={"log_id": log_id})
 
 
-@mcp.tool
-def reject_purchase(log_id: str) -> dict:
-    """Reject a purchase request. Parent-only."""
-    return _post("/parent/purchase-requests/reject", json={"log_id": log_id})
+@mcp.tool()
+async def reject_purchase(log_id: str) -> str:
+    """Reject a purchase request and refund points. Parent-only.
+
+    Args:
+        log_id: ID of the purchase log entry to reject.
+    """
+    return await _post("/parent/purchase-requests/reject", json_data={"log_id": log_id})
 
 
 # ── Requests (Feature/Item requests from kids) ───────────────
 
 
-@mcp.tool
-def create_request(request_type: str, title: str, description: str = "") -> dict:
-    """Create a feature or item request. Kid action. request_type: 'chore' or 'store_item'."""
-    return _post(
+@mcp.tool()
+async def create_request(request_type: str, title: str, description: str = "") -> str:
+    """Create a feature or item request. Kid action.
+
+    Args:
+        request_type: Type of request - 'chore' or 'store_item'.
+        title: Short title for the request.
+        description: Detailed description of what's being requested.
+    """
+    return await _post(
         "/requests/",
-        json={"request_type": request_type, "title": title, "description": description},
+        json_data={"request_type": request_type, "title": title, "description": description},
     )
 
 
-@mcp.tool
-def get_my_requests(
+@mcp.tool()
+async def get_my_requests(
     status: Optional[str] = None,
     request_type: Optional[str] = None,
     limit: int = 100,
     offset: int = 0,
-) -> dict:
-    """Get the current kid's requests. Filter by status and type."""
+) -> str:
+    """Get the current kid's submitted requests.
+
+    Args:
+        status: Filter by status - 'pending', 'approved', 'rejected'.
+        request_type: Filter by type - 'chore' or 'store_item'.
+        limit: Maximum number of results (1-500).
+        offset: Number of results to skip for pagination.
+    """
     params = {"limit": limit, "offset": offset}
     if status:
         params["status"] = status
     if request_type:
         params["type"] = request_type
-    return _get("/requests/me/", params=params)
+    return await _get("/requests/me/", params=params)
 
 
-@mcp.tool
-def get_pending_requests() -> dict:
-    """Get all pending feature/item requests. Parent-only."""
-    return _get("/parent/requests/pending/")
+@mcp.tool()
+async def get_pending_requests() -> str:
+    """Get all pending feature/item requests from kids. Parent-only."""
+    return await _get("/parent/requests/pending/")
 
 
-@mcp.tool
-def approve_request(request_id: str) -> dict:
-    """Approve a kid's request. Parent-only."""
-    return _post(f"/parent/requests/{request_id}/approve/")
+@mcp.tool()
+async def approve_request(request_id: str) -> str:
+    """Approve a kid's feature/item request. Parent-only.
+
+    Args:
+        request_id: ID of the request to approve.
+    """
+    return await _post(f"/parent/requests/{request_id}/approve/")
 
 
-@mcp.tool
-def reject_request(request_id: str, reason: str = "") -> dict:
-    """Reject a kid's request. Parent-only."""
-    return _post(f"/parent/requests/{request_id}/reject/", json={"reason": reason})
+@mcp.tool()
+async def reject_request(request_id: str, reason: str = "") -> str:
+    """Reject a kid's feature/item request. Parent-only.
+
+    Args:
+        request_id: ID of the request to reject.
+        reason: Optional explanation for the rejection.
+    """
+    return await _post(f"/parent/requests/{request_id}/reject/", json_data={"reason": reason})
 
 
 # ── Pets ──────────────────────────────────────────────────────
 
 
-@mcp.tool
-def list_pets() -> dict:
-    """List all family pets."""
-    return _get("/pets/")
+@mcp.tool()
+async def list_pets() -> str:
+    """List all family pets with their profiles and calculated ages."""
+    return await _get("/pets/")
 
 
-@mcp.tool
-def get_pet(pet_id: str) -> dict:
-    """Get a specific pet's profile including age."""
-    return _get(f"/pets/{pet_id}")
+@mcp.tool()
+async def get_pet(pet_id: str) -> str:
+    """Get a specific pet's full profile including age.
+
+    Args:
+        pet_id: The unique identifier of the pet.
+    """
+    return await _get(f"/pets/{pet_id}")
 
 
-@mcp.tool
-def create_pet(
-    name: str,
-    species: str,
-    birthday: Optional[str] = None,
-    photo_url: Optional[str] = None,
-) -> dict:
-    """Create a new pet. Parent-only. birthday format: YYYY-MM-DD."""
+@mcp.tool()
+async def create_pet(
+    name: str, species: str, birthday: Optional[str] = None, photo_url: Optional[str] = None
+) -> str:
+    """Create a new pet profile. Parent-only.
+
+    Args:
+        name: The pet's name.
+        species: Species/breed (e.g. 'bearded dragon', 'cat', 'dog').
+        birthday: Pet's birthday in YYYY-MM-DD format.
+        photo_url: URL to a photo of the pet.
+    """
     payload = {"name": name, "species": species}
     if birthday:
         payload["birthday"] = birthday
     if photo_url:
         payload["photo_url"] = photo_url
-    return _post("/pets/", json=payload)
+    return await _post("/pets/", json_data=payload)
 
 
-@mcp.tool
-def update_pet(
-    pet_id: str,
-    name: str,
-    species: str,
-    birthday: Optional[str] = None,
-    photo_url: Optional[str] = None,
-) -> dict:
-    """Update a pet's profile. Parent-only."""
+@mcp.tool()
+async def update_pet(
+    pet_id: str, name: str, species: str, birthday: Optional[str] = None, photo_url: Optional[str] = None
+) -> str:
+    """Update a pet's profile. Parent-only.
+
+    Args:
+        pet_id: ID of the pet to update.
+        name: Updated pet name.
+        species: Updated species.
+        birthday: Updated birthday in YYYY-MM-DD format.
+        photo_url: Updated photo URL.
+    """
     payload = {"name": name, "species": species}
     if birthday:
         payload["birthday"] = birthday
     if photo_url:
         payload["photo_url"] = photo_url
-    return _put(f"/pets/{pet_id}", json=payload)
+    return await _put(f"/pets/{pet_id}", json_data=payload)
 
 
-@mcp.tool
-def deactivate_pet(pet_id: str) -> dict:
-    """Deactivate a pet. Parent-only."""
-    return _post(f"/pets/{pet_id}/deactivate")
+@mcp.tool()
+async def deactivate_pet(pet_id: str) -> str:
+    """Deactivate a pet profile. Parent-only.
+
+    Args:
+        pet_id: ID of the pet to deactivate.
+    """
+    return await _post(f"/pets/{pet_id}/deactivate")
 
 
-@mcp.tool
-def get_care_recommendations(pet_id: str) -> dict:
-    """Get AI-generated care recommendations for a pet."""
-    return _get(f"/pets/{pet_id}/care-recommendations")
+@mcp.tool()
+async def get_care_recommendations(pet_id: str) -> str:
+    """Get AI-generated care recommendations tailored to this pet's species and age.
+
+    Args:
+        pet_id: ID of the pet to get recommendations for.
+    """
+    return await _get(f"/pets/{pet_id}/care-recommendations")
 
 
-@mcp.tool
-def get_recommended_schedules(pet_id: str) -> dict:
-    """Get recommended care schedules for a pet based on species."""
-    return _get(f"/pets/{pet_id}/recommended-schedules")
+@mcp.tool()
+async def get_recommended_schedules(pet_id: str) -> str:
+    """Get suggested care schedules for a pet based on its species.
+
+    Args:
+        pet_id: ID of the pet to get schedule recommendations for.
+    """
+    return await _get(f"/pets/{pet_id}/recommended-schedules")
 
 
 # ── Pet Schedules ─────────────────────────────────────────────
 
 
-@mcp.tool
-def create_schedule(
+@mcp.tool()
+async def create_schedule(
     pet_id: str,
     care_type: str,
     frequency: str,
     assigned_kid_ids: list[str],
     task_name: str = "",
     points_value: int = 5,
-) -> dict:
-    """Create a pet care schedule. Parent-only. care_type: feeding/cleaning/exercise/etc."""
-    return _post(
+) -> str:
+    """Create a recurring pet care schedule. Parent-only.
+
+    Args:
+        pet_id: ID of the pet this schedule is for.
+        care_type: Type of care - 'feeding', 'cleaning', 'exercise', etc.
+        frequency: How often - 'daily', 'weekly', etc.
+        assigned_kid_ids: List of kid usernames to rotate through.
+        task_name: Custom name for generated tasks.
+        points_value: Points awarded per completed task.
+    """
+    return await _post(
         "/pets/schedules/",
-        json={
+        json_data={
             "pet_id": pet_id,
             "care_type": care_type,
             "frequency": frequency,
@@ -517,156 +718,219 @@ def create_schedule(
     )
 
 
-@mcp.tool
-def list_schedules(pet_id: str) -> dict:
-    """List care schedules for a specific pet."""
-    return _get(f"/pets/{pet_id}/schedules/")
+@mcp.tool()
+async def list_schedules(pet_id: str) -> str:
+    """List all care schedules for a specific pet.
+
+    Args:
+        pet_id: ID of the pet to list schedules for.
+    """
+    return await _get(f"/pets/{pet_id}/schedules/")
 
 
-@mcp.tool
-def deactivate_schedule(schedule_id: str) -> dict:
-    """Deactivate a pet care schedule. Parent-only."""
-    return _post(f"/pets/schedules/{schedule_id}/deactivate")
+@mcp.tool()
+async def deactivate_schedule(schedule_id: str) -> str:
+    """Deactivate a pet care schedule. Parent-only.
+
+    Args:
+        schedule_id: ID of the schedule to deactivate.
+    """
+    return await _post(f"/pets/schedules/{schedule_id}/deactivate")
 
 
-@mcp.tool
-def generate_tasks(schedule_id: str, days: int = 7) -> dict:
-    """Generate pet care tasks from a schedule for the next N days."""
-    return _post(f"/pets/schedules/{schedule_id}/generate-tasks", json={"days": days})
+@mcp.tool()
+async def generate_tasks(schedule_id: str, days: int = 7) -> str:
+    """Generate pet care task instances from a schedule.
+
+    Args:
+        schedule_id: ID of the schedule to generate tasks from.
+        days: Number of days ahead to generate tasks for (default 7).
+    """
+    return await _post(f"/pets/schedules/{schedule_id}/generate-tasks", json_data={"days": days})
 
 
 # ── Pet Tasks ─────────────────────────────────────────────────
 
 
-@mcp.tool
-def get_my_pet_tasks(
-    status: Optional[str] = None,
-    limit: int = 100,
-    offset: int = 0,
-) -> dict:
-    """Get the current kid's pet care tasks. Filter by status."""
+@mcp.tool()
+async def get_my_pet_tasks(status: Optional[str] = None, limit: int = 100, offset: int = 0) -> str:
+    """Get the current kid's assigned pet care tasks.
+
+    Args:
+        status: Filter by status - 'scheduled', 'assigned', 'pending_approval', 'approved', 'rejected'.
+        limit: Maximum number of results (1-500).
+        offset: Number of results to skip for pagination.
+    """
     params = {"limit": limit, "offset": offset}
     if status:
         params["status"] = status
-    return _get("/kids/my-pet-tasks/", params=params)
+    return await _get("/kids/my-pet-tasks/", params=params)
 
 
-@mcp.tool
-def get_pet_tasks(pet_id: str) -> dict:
-    """Get all care tasks for a specific pet."""
-    return _get(f"/pets/{pet_id}/tasks/")
+@mcp.tool()
+async def get_pet_tasks(pet_id: str) -> str:
+    """Get all care tasks for a specific pet.
+
+    Args:
+        pet_id: ID of the pet to list tasks for.
+    """
+    return await _get(f"/pets/{pet_id}/tasks/")
 
 
-@mcp.tool
-def submit_pet_task(task_id: str, notes: str = "") -> dict:
-    """Submit a pet care task as completed. Kid action."""
-    return _post(f"/pets/tasks/{task_id}/submit", json={"notes": notes})
+@mcp.tool()
+async def submit_pet_task(task_id: str, notes: str = "") -> str:
+    """Submit a pet care task as completed. Kid action.
+
+    Args:
+        task_id: ID of the pet care task to submit.
+        notes: Optional notes about the completion.
+    """
+    return await _post(f"/pets/tasks/{task_id}/submit", json_data={"notes": notes})
 
 
-@mcp.tool
-def get_pending_pet_task_submissions() -> dict:
-    """Get pending pet task submissions. Parent-only."""
-    return _get("/parent/pet-task-submissions/pending")
+@mcp.tool()
+async def get_pending_pet_task_submissions() -> str:
+    """Get all pet care task submissions awaiting parent approval. Parent-only."""
+    return await _get("/parent/pet-task-submissions/pending")
 
 
-@mcp.tool
-def approve_pet_task(task_id: str) -> dict:
-    """Approve a pet task submission. Parent-only."""
-    return _post("/parent/pet-task-submissions/approve", json={"task_id": task_id})
+@mcp.tool()
+async def approve_pet_task(task_id: str) -> str:
+    """Approve a pet care task submission and award points. Parent-only.
+
+    Args:
+        task_id: ID of the pet care task to approve.
+    """
+    return await _post("/parent/pet-task-submissions/approve", json_data={"task_id": task_id})
 
 
-@mcp.tool
-def reject_pet_task(task_id: str, reason: str = "") -> dict:
-    """Reject a pet task submission. Parent-only."""
-    return _post("/parent/pet-task-submissions/reject", json={"task_id": task_id, "reason": reason})
+@mcp.tool()
+async def reject_pet_task(task_id: str, reason: str = "") -> str:
+    """Reject a pet care task submission. Parent-only.
+
+    Args:
+        task_id: ID of the pet care task to reject.
+        reason: Optional explanation for the rejection.
+    """
+    return await _post("/parent/pet-task-submissions/reject", json_data={"task_id": task_id, "reason": reason})
 
 
 # ── Pet Health ────────────────────────────────────────────────
 
 
-@mcp.tool
-def add_health_log(
-    pet_id: str,
-    weight_grams: float,
-    notes: str = "",
-) -> dict:
-    """Log a pet's weight/health data. Parent-only."""
-    return _post(
-        f"/pets/{pet_id}/health-logs/",
-        json={"weight_grams": weight_grams, "notes": notes},
-    )
+@mcp.tool()
+async def add_health_log(pet_id: str, weight_grams: float, notes: str = "") -> str:
+    """Log a pet's weight measurement. Parent-only.
+
+    Args:
+        pet_id: ID of the pet.
+        weight_grams: Weight in grams.
+        notes: Optional health observations.
+    """
+    return await _post(f"/pets/{pet_id}/health-logs/", json_data={"weight_grams": weight_grams, "notes": notes})
 
 
-@mcp.tool
-def get_health_logs(pet_id: str) -> dict:
-    """Get health/weight logs for a specific pet."""
-    return _get(f"/pets/{pet_id}/health-logs/")
+@mcp.tool()
+async def get_health_logs(pet_id: str) -> str:
+    """Get weight and health tracking logs for a pet.
+
+    Args:
+        pet_id: ID of the pet to get health logs for.
+    """
+    return await _get(f"/pets/{pet_id}/health-logs/")
 
 
 # ── Dashboards & Info ─────────────────────────────────────────
 
 
-@mcp.tool
-def get_parent_dashboard() -> dict:
-    """Get parent dashboard with pending counts for all categories."""
-    return _get("/parent/dashboard")
+@mcp.tool()
+async def get_parent_dashboard() -> str:
+    """Get parent dashboard showing pending counts for chores, purchases, assignments, requests, and pet tasks."""
+    return await _get("/parent/dashboard")
 
 
-@mcp.tool
-def get_kid_dashboard() -> dict:
-    """Get kid dashboard with points, active tasks, and streak."""
-    return _get("/kid/dashboard")
+@mcp.tool()
+async def get_kid_dashboard() -> str:
+    """Get kid dashboard showing current points, active assignments, active pet tasks, and streak data."""
+    return await _get("/kid/dashboard")
 
 
-@mcp.tool
-def get_pet_overview() -> dict:
-    """Get overview of all pets with schedules and task summaries."""
-    return _get("/pets/overview/")
+@mcp.tool()
+async def get_pet_overview() -> str:
+    """Get a summary overview of all pets including their schedules and task statistics."""
+    return await _get("/pets/overview/")
 
 
-@mcp.tool
-def get_points_rules() -> dict:
-    """Get business rules for points calculation, streaks, and pricing."""
-    return _get("/config/points-rules")
+# ── Resources ─────────────────────────────────────────────────
+
+
+@mcp.resource("config://points-rules")
+async def get_points_rules() -> str:
+    """Business rules for points calculation, streak milestones, and suggested pricing formulas."""
+    return await _get("/config/points-rules")
 
 
 # ── Lookup by ID ──────────────────────────────────────────────
 
 
-@mcp.tool
-def get_purchase_log(log_id: str) -> dict:
-    """Get a specific purchase log by ID."""
-    return _get(f"/purchase-logs/{log_id}")
+@mcp.tool()
+async def get_purchase_log(log_id: str) -> str:
+    """Get a specific purchase log entry by ID.
+
+    Args:
+        log_id: The unique identifier of the purchase log.
+    """
+    return await _get(f"/purchase-logs/{log_id}")
 
 
-@mcp.tool
-def get_chore_log(log_id: str) -> dict:
-    """Get a specific chore log by ID."""
-    return _get(f"/chore-logs/{log_id}")
+@mcp.tool()
+async def get_chore_log(log_id: str) -> str:
+    """Get a specific chore log entry by ID.
+
+    Args:
+        log_id: The unique identifier of the chore log.
+    """
+    return await _get(f"/chore-logs/{log_id}")
 
 
-@mcp.tool
-def get_request_by_id(request_id: str) -> dict:
-    """Get a specific request by ID."""
-    return _get(f"/requests/{request_id}")
+@mcp.tool()
+async def get_request_by_id(request_id: str) -> str:
+    """Get a specific feature/item request by ID.
+
+    Args:
+        request_id: The unique identifier of the request.
+    """
+    return await _get(f"/requests/{request_id}")
 
 
-@mcp.tool
-def get_assignment(assignment_id: str) -> dict:
-    """Get a specific chore assignment by ID."""
-    return _get(f"/chore-assignments/{assignment_id}")
+@mcp.tool()
+async def get_assignment(assignment_id: str) -> str:
+    """Get a specific chore assignment by ID.
+
+    Args:
+        assignment_id: The unique identifier of the assignment.
+    """
+    return await _get(f"/chore-assignments/{assignment_id}")
 
 
-@mcp.tool
-def get_pet_task(task_id: str) -> dict:
-    """Get a specific pet care task by ID."""
-    return _get(f"/pets/tasks/{task_id}")
+@mcp.tool()
+async def get_pet_task(task_id: str) -> str:
+    """Get a specific pet care task by ID.
+
+    Args:
+        task_id: The unique identifier of the pet care task.
+    """
+    return await _get(f"/pets/tasks/{task_id}")
 
 
-@mcp.tool
-def get_schedule(schedule_id: str) -> dict:
-    """Get a specific pet care schedule by ID."""
-    return _get(f"/pets/schedules/{schedule_id}")
+@mcp.tool()
+async def get_schedule(schedule_id: str) -> str:
+    """Get a specific pet care schedule by ID.
+
+    Args:
+        schedule_id: The unique identifier of the schedule.
+    """
+    return await _get(f"/pets/schedules/{schedule_id}")
 
 
 if __name__ == "__main__":

--- a/mcp_server/server.py
+++ b/mcp_server/server.py
@@ -1,0 +1,673 @@
+import os
+from typing import Optional
+
+import httpx
+from fastmcp import FastMCP
+
+BASE_URL = os.environ.get("KIDS_REWARDS_API_URL", "http://localhost:3000")
+
+mcp = FastMCP(
+    "Kids Rewards",
+    instructions=(
+        "Manage a family chore and reward system. Parents create chores and store items, "
+        "kids earn points by completing chores, and redeem points for rewards. "
+        "Includes pet care management. You must login first to get a token."
+    ),
+)
+
+_token: str | None = None
+
+
+def _headers() -> dict:
+    if _token:
+        return {"Authorization": f"Bearer {_token}"}
+    return {}
+
+
+def _url(path: str) -> str:
+    return f"{BASE_URL}{path}"
+
+
+def _get(path: str, params: dict | None = None) -> dict:
+    r = httpx.get(_url(path), headers=_headers(), params=params, timeout=30)
+    return r.json()
+
+
+def _post(path: str, json: dict | None = None, data: dict | None = None) -> dict:
+    r = httpx.post(_url(path), headers=_headers(), json=json, data=data, timeout=30)
+    return r.json()
+
+
+def _put(path: str, json: dict) -> dict:
+    r = httpx.put(_url(path), headers=_headers(), json=json, timeout=30)
+    return r.json()
+
+
+def _delete(path: str) -> dict:
+    r = httpx.delete(_url(path), headers=_headers(), timeout=30)
+    if r.status_code == 200:
+        return r.json()
+    return {"success": True, "data": None}
+
+
+# ── Auth & Users ──────────────────────────────────────────────
+
+
+@mcp.tool
+def login(username: str, password: str) -> dict:
+    """Authenticate and store token. Must be called before other tools."""
+    global _token
+    r = httpx.post(
+        _url("/token"),
+        data={"username": username, "password": password},
+        timeout=30,
+    )
+    result = r.json()
+    if "access_token" in result:
+        _token = result["access_token"]
+        return {"success": True, "message": f"Logged in as {username}"}
+    return {"success": False, "error": result}
+
+
+@mcp.tool
+def register_user(username: str, password: str, role: str = "kid") -> dict:
+    """Register a new user account. Role: 'kid' or 'parent'."""
+    return _post("/users/", json={"username": username, "password": password, "role": role})
+
+
+@mcp.tool
+def get_current_user() -> dict:
+    """Get the currently authenticated user's profile."""
+    return _get("/users/me/")
+
+
+@mcp.tool
+def list_users(role: Optional[str] = None, limit: int = 100, offset: int = 0) -> dict:
+    """List all users. Parent-only. Optional filter by role ('kid' or 'parent')."""
+    params = {"limit": limit, "offset": offset}
+    if role:
+        params["role"] = role
+    return _get("/users/", params=params)
+
+
+@mcp.tool
+def promote_to_parent(username: str) -> dict:
+    """Promote a kid user to parent role. Parent-only."""
+    return _post("/users/promote-to-parent", json={"username": username})
+
+
+@mcp.tool
+def award_points(kid_username: str, points: int) -> dict:
+    """Award bonus points to a kid. Parent-only."""
+    return _post("/kids/award-points/", json={"kid_username": kid_username, "points": points})
+
+
+@mcp.tool
+def get_leaderboard() -> dict:
+    """Get all users sorted by points (highest first)."""
+    return _get("/leaderboard")
+
+
+# ── Store ─────────────────────────────────────────────────────
+
+
+@mcp.tool
+def list_store_items(
+    sort: Optional[str] = None,
+    order: str = "asc",
+    limit: int = 100,
+    offset: int = 0,
+) -> dict:
+    """List store items. Sort by 'points_cost' or 'name'. Order: 'asc' or 'desc'."""
+    params = {"limit": limit, "offset": offset, "order": order}
+    if sort:
+        params["sort"] = sort
+    return _get("/store/items/", params=params)
+
+
+@mcp.tool
+def get_store_item(item_id: str) -> dict:
+    """Get a specific store item by ID."""
+    return _get(f"/store/items/{item_id}")
+
+
+@mcp.tool
+def create_store_item(name: str, points_cost: int, description: str = "") -> dict:
+    """Create a new store reward item. Parent-only."""
+    return _post("/store/items/", json={"name": name, "points_cost": points_cost, "description": description})
+
+
+@mcp.tool
+def update_store_item(item_id: str, name: str, points_cost: int, description: str = "") -> dict:
+    """Update an existing store item. Parent-only."""
+    return _put(f"/store/items/{item_id}", json={"name": name, "points_cost": points_cost, "description": description})
+
+
+@mcp.tool
+def delete_store_item(item_id: str) -> dict:
+    """Delete a store item. Parent-only."""
+    return _delete(f"/store/items/{item_id}")
+
+
+@mcp.tool
+def purchase_store_item(item_id: str) -> dict:
+    """Purchase a store item using points. Kid action."""
+    return _post("/store/items/purchase", json={"item_id": item_id})
+
+
+# ── Chores ────────────────────────────────────────────────────
+
+
+@mcp.tool
+def list_chores(include_inactive: bool = False, limit: int = 100, offset: int = 0) -> dict:
+    """List available chores. Set include_inactive=True to see all."""
+    params = {"limit": limit, "offset": offset}
+    if include_inactive:
+        params["include_inactive"] = "true"
+    return _get("/chores/", params=params)
+
+
+@mcp.tool
+def get_chore(chore_id: str) -> dict:
+    """Get a specific chore by ID."""
+    return _get(f"/chores/{chore_id}")
+
+
+@mcp.tool
+def create_chore(
+    name: str,
+    description: str,
+    points_value: int,
+    is_active: bool = True,
+) -> dict:
+    """Create a new chore. Parent-only."""
+    return _post(
+        "/chores/",
+        json={
+            "name": name,
+            "description": description,
+            "points_value": points_value,
+            "is_active": is_active,
+        },
+    )
+
+
+@mcp.tool
+def update_chore(
+    chore_id: str,
+    name: str,
+    description: str,
+    points_value: int,
+    is_active: bool = True,
+) -> dict:
+    """Update an existing chore. Parent-only."""
+    return _put(
+        f"/chores/{chore_id}",
+        json={
+            "name": name,
+            "description": description,
+            "points_value": points_value,
+            "is_active": is_active,
+        },
+    )
+
+
+@mcp.tool
+def deactivate_chore(chore_id: str) -> dict:
+    """Deactivate a chore. Parent-only."""
+    return _post(f"/chores/{chore_id}/deactivate")
+
+
+@mcp.tool
+def delete_chore(chore_id: str) -> dict:
+    """Delete a chore. Parent-only."""
+    return _delete(f"/chores/{chore_id}")
+
+
+@mcp.tool
+def submit_chore(chore_id: str, effort_minutes: int = 0) -> dict:
+    """Submit a chore completion. Kid action. effort_minutes tracks time spent."""
+    return _post(f"/chores/{chore_id}/submit", json={"effort_minutes": effort_minutes})
+
+
+# ── Chore History & Stats ─────────────────────────────────────
+
+
+@mcp.tool
+def get_my_chore_history(
+    status: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict:
+    """Get the current kid's chore submission history. Filter by status."""
+    params = {"limit": limit, "offset": offset}
+    if status:
+        params["status"] = status
+    return _get("/chores/history/me", params=params)
+
+
+@mcp.tool
+def get_my_chore_stats() -> dict:
+    """Get aggregated chore statistics for the current kid."""
+    return _get("/chores/history/me/stats")
+
+
+@mcp.tool
+def get_my_streak() -> dict:
+    """Get the current kid's streak information."""
+    return _get("/kids/streak/")
+
+
+# ── Chore Submissions (Parent) ───────────────────────────────
+
+
+@mcp.tool
+def get_pending_chore_submissions() -> dict:
+    """Get all pending chore submissions awaiting parent approval."""
+    return _get("/parent/chore-submissions/pending")
+
+
+@mcp.tool
+def approve_chore_submission(log_id: str) -> dict:
+    """Approve a kid's chore submission. Parent-only."""
+    return _post("/parent/chore-submissions/approve", json={"log_id": log_id})
+
+
+@mcp.tool
+def reject_chore_submission(log_id: str, reason: str = "") -> dict:
+    """Reject a kid's chore submission. Parent-only."""
+    return _post("/parent/chore-submissions/reject", json={"log_id": log_id, "reason": reason})
+
+
+# ── Chore Assignments ─────────────────────────────────────────
+
+
+@mcp.tool
+def create_assignment(
+    chore_id: str,
+    kid_username: str,
+    due_date: Optional[str] = None,
+    notes: str = "",
+) -> dict:
+    """Assign a chore to a kid. Parent-only. due_date format: YYYY-MM-DD."""
+    payload = {"chore_id": chore_id, "kid_username": kid_username, "notes": notes}
+    if due_date:
+        payload["due_date"] = due_date
+    return _post("/parent/chore-assignments/", json=payload)
+
+
+@mcp.tool
+def get_my_assignments(
+    status: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict:
+    """Get the current kid's assigned chores. Filter by status."""
+    params = {"limit": limit, "offset": offset}
+    if status:
+        params["status"] = status
+    return _get("/kids/my-assignments/", params=params)
+
+
+@mcp.tool
+def submit_assignment(assignment_id: str, notes: str = "") -> dict:
+    """Submit an assignment completion. Kid action."""
+    return _post(
+        f"/kids/my-assignments/{assignment_id}/submit",
+        json={"notes": notes},
+    )
+
+
+@mcp.tool
+def get_pending_assignment_submissions() -> dict:
+    """Get pending assignment submissions. Parent-only."""
+    return _get("/parent/assignment-submissions/pending")
+
+
+@mcp.tool
+def approve_assignment(assignment_id: str) -> dict:
+    """Approve a kid's assignment submission. Parent-only."""
+    return _post("/parent/assignment-submissions/approve", json={"assignment_id": assignment_id})
+
+
+@mcp.tool
+def reject_assignment(assignment_id: str, reason: str = "") -> dict:
+    """Reject a kid's assignment submission. Parent-only."""
+    return _post(
+        "/parent/assignment-submissions/reject",
+        json={"assignment_id": assignment_id, "reason": reason},
+    )
+
+
+@mcp.tool
+def list_parent_assignments() -> dict:
+    """List all chore assignments created by the current parent."""
+    return _get("/parent/chore-assignments/")
+
+
+# ── Purchases ─────────────────────────────────────────────────
+
+
+@mcp.tool
+def get_my_purchase_history(
+    status: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict:
+    """Get the current user's purchase history. Filter by status."""
+    params = {"limit": limit, "offset": offset}
+    if status:
+        params["status"] = status
+    return _get("/users/me/purchase-history", params=params)
+
+
+@mcp.tool
+def get_pending_purchases() -> dict:
+    """Get all pending purchase requests. Parent-only."""
+    return _get("/parent/purchase-requests/pending")
+
+
+@mcp.tool
+def approve_purchase(log_id: str) -> dict:
+    """Approve a purchase request. Parent-only."""
+    return _post("/parent/purchase-requests/approve", json={"log_id": log_id})
+
+
+@mcp.tool
+def reject_purchase(log_id: str) -> dict:
+    """Reject a purchase request. Parent-only."""
+    return _post("/parent/purchase-requests/reject", json={"log_id": log_id})
+
+
+# ── Requests (Feature/Item requests from kids) ───────────────
+
+
+@mcp.tool
+def create_request(request_type: str, title: str, description: str = "") -> dict:
+    """Create a feature or item request. Kid action. request_type: 'chore' or 'store_item'."""
+    return _post(
+        "/requests/",
+        json={"request_type": request_type, "title": title, "description": description},
+    )
+
+
+@mcp.tool
+def get_my_requests(
+    status: Optional[str] = None,
+    request_type: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict:
+    """Get the current kid's requests. Filter by status and type."""
+    params = {"limit": limit, "offset": offset}
+    if status:
+        params["status"] = status
+    if request_type:
+        params["type"] = request_type
+    return _get("/requests/me/", params=params)
+
+
+@mcp.tool
+def get_pending_requests() -> dict:
+    """Get all pending feature/item requests. Parent-only."""
+    return _get("/parent/requests/pending/")
+
+
+@mcp.tool
+def approve_request(request_id: str) -> dict:
+    """Approve a kid's request. Parent-only."""
+    return _post(f"/parent/requests/{request_id}/approve/")
+
+
+@mcp.tool
+def reject_request(request_id: str, reason: str = "") -> dict:
+    """Reject a kid's request. Parent-only."""
+    return _post(f"/parent/requests/{request_id}/reject/", json={"reason": reason})
+
+
+# ── Pets ──────────────────────────────────────────────────────
+
+
+@mcp.tool
+def list_pets() -> dict:
+    """List all family pets."""
+    return _get("/pets/")
+
+
+@mcp.tool
+def get_pet(pet_id: str) -> dict:
+    """Get a specific pet's profile including age."""
+    return _get(f"/pets/{pet_id}")
+
+
+@mcp.tool
+def create_pet(
+    name: str,
+    species: str,
+    birthday: Optional[str] = None,
+    photo_url: Optional[str] = None,
+) -> dict:
+    """Create a new pet. Parent-only. birthday format: YYYY-MM-DD."""
+    payload = {"name": name, "species": species}
+    if birthday:
+        payload["birthday"] = birthday
+    if photo_url:
+        payload["photo_url"] = photo_url
+    return _post("/pets/", json=payload)
+
+
+@mcp.tool
+def update_pet(
+    pet_id: str,
+    name: str,
+    species: str,
+    birthday: Optional[str] = None,
+    photo_url: Optional[str] = None,
+) -> dict:
+    """Update a pet's profile. Parent-only."""
+    payload = {"name": name, "species": species}
+    if birthday:
+        payload["birthday"] = birthday
+    if photo_url:
+        payload["photo_url"] = photo_url
+    return _put(f"/pets/{pet_id}", json=payload)
+
+
+@mcp.tool
+def deactivate_pet(pet_id: str) -> dict:
+    """Deactivate a pet. Parent-only."""
+    return _post(f"/pets/{pet_id}/deactivate")
+
+
+@mcp.tool
+def get_care_recommendations(pet_id: str) -> dict:
+    """Get AI-generated care recommendations for a pet."""
+    return _get(f"/pets/{pet_id}/care-recommendations")
+
+
+@mcp.tool
+def get_recommended_schedules(pet_id: str) -> dict:
+    """Get recommended care schedules for a pet based on species."""
+    return _get(f"/pets/{pet_id}/recommended-schedules")
+
+
+# ── Pet Schedules ─────────────────────────────────────────────
+
+
+@mcp.tool
+def create_schedule(
+    pet_id: str,
+    care_type: str,
+    frequency: str,
+    assigned_kid_ids: list[str],
+    task_name: str = "",
+    points_value: int = 5,
+) -> dict:
+    """Create a pet care schedule. Parent-only. care_type: feeding/cleaning/exercise/etc."""
+    return _post(
+        "/pets/schedules/",
+        json={
+            "pet_id": pet_id,
+            "care_type": care_type,
+            "frequency": frequency,
+            "assigned_kid_ids": assigned_kid_ids,
+            "task_name": task_name,
+            "points_value": points_value,
+        },
+    )
+
+
+@mcp.tool
+def list_schedules(pet_id: str) -> dict:
+    """List care schedules for a specific pet."""
+    return _get(f"/pets/{pet_id}/schedules/")
+
+
+@mcp.tool
+def deactivate_schedule(schedule_id: str) -> dict:
+    """Deactivate a pet care schedule. Parent-only."""
+    return _post(f"/pets/schedules/{schedule_id}/deactivate")
+
+
+@mcp.tool
+def generate_tasks(schedule_id: str, days: int = 7) -> dict:
+    """Generate pet care tasks from a schedule for the next N days."""
+    return _post(f"/pets/schedules/{schedule_id}/generate-tasks", json={"days": days})
+
+
+# ── Pet Tasks ─────────────────────────────────────────────────
+
+
+@mcp.tool
+def get_my_pet_tasks(
+    status: Optional[str] = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> dict:
+    """Get the current kid's pet care tasks. Filter by status."""
+    params = {"limit": limit, "offset": offset}
+    if status:
+        params["status"] = status
+    return _get("/kids/my-pet-tasks/", params=params)
+
+
+@mcp.tool
+def get_pet_tasks(pet_id: str) -> dict:
+    """Get all care tasks for a specific pet."""
+    return _get(f"/pets/{pet_id}/tasks/")
+
+
+@mcp.tool
+def submit_pet_task(task_id: str, notes: str = "") -> dict:
+    """Submit a pet care task as completed. Kid action."""
+    return _post(f"/pets/tasks/{task_id}/submit", json={"notes": notes})
+
+
+@mcp.tool
+def get_pending_pet_task_submissions() -> dict:
+    """Get pending pet task submissions. Parent-only."""
+    return _get("/parent/pet-task-submissions/pending")
+
+
+@mcp.tool
+def approve_pet_task(task_id: str) -> dict:
+    """Approve a pet task submission. Parent-only."""
+    return _post("/parent/pet-task-submissions/approve", json={"task_id": task_id})
+
+
+@mcp.tool
+def reject_pet_task(task_id: str, reason: str = "") -> dict:
+    """Reject a pet task submission. Parent-only."""
+    return _post("/parent/pet-task-submissions/reject", json={"task_id": task_id, "reason": reason})
+
+
+# ── Pet Health ────────────────────────────────────────────────
+
+
+@mcp.tool
+def add_health_log(
+    pet_id: str,
+    weight_grams: float,
+    notes: str = "",
+) -> dict:
+    """Log a pet's weight/health data. Parent-only."""
+    return _post(
+        f"/pets/{pet_id}/health-logs/",
+        json={"weight_grams": weight_grams, "notes": notes},
+    )
+
+
+@mcp.tool
+def get_health_logs(pet_id: str) -> dict:
+    """Get health/weight logs for a specific pet."""
+    return _get(f"/pets/{pet_id}/health-logs/")
+
+
+# ── Dashboards & Info ─────────────────────────────────────────
+
+
+@mcp.tool
+def get_parent_dashboard() -> dict:
+    """Get parent dashboard with pending counts for all categories."""
+    return _get("/parent/dashboard")
+
+
+@mcp.tool
+def get_kid_dashboard() -> dict:
+    """Get kid dashboard with points, active tasks, and streak."""
+    return _get("/kid/dashboard")
+
+
+@mcp.tool
+def get_pet_overview() -> dict:
+    """Get overview of all pets with schedules and task summaries."""
+    return _get("/pets/overview/")
+
+
+@mcp.tool
+def get_points_rules() -> dict:
+    """Get business rules for points calculation, streaks, and pricing."""
+    return _get("/config/points-rules")
+
+
+# ── Lookup by ID ──────────────────────────────────────────────
+
+
+@mcp.tool
+def get_purchase_log(log_id: str) -> dict:
+    """Get a specific purchase log by ID."""
+    return _get(f"/purchase-logs/{log_id}")
+
+
+@mcp.tool
+def get_chore_log(log_id: str) -> dict:
+    """Get a specific chore log by ID."""
+    return _get(f"/chore-logs/{log_id}")
+
+
+@mcp.tool
+def get_request_by_id(request_id: str) -> dict:
+    """Get a specific request by ID."""
+    return _get(f"/requests/{request_id}")
+
+
+@mcp.tool
+def get_assignment(assignment_id: str) -> dict:
+    """Get a specific chore assignment by ID."""
+    return _get(f"/chore-assignments/{assignment_id}")
+
+
+@mcp.tool
+def get_pet_task(task_id: str) -> dict:
+    """Get a specific pet care task by ID."""
+    return _get(f"/pets/tasks/{task_id}")
+
+
+@mcp.tool
+def get_schedule(schedule_id: str) -> dict:
+    """Get a specific pet care schedule by ID."""
+    return _get(f"/pets/schedules/{schedule_id}")
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/mcp_server/tests/test_server.py
+++ b/mcp_server/tests/test_server.py
@@ -20,7 +20,6 @@ def test_server_loads_all_tools():
         "submit_chore",
         "approve_chore_submission",
         "create_pet",
-        "get_points_rules",
     ]
     for name in expected:
         assert name in tools, f"Missing tool: {name}"
@@ -30,6 +29,11 @@ def test_tool_descriptions_exist():
     tools = asyncio.run(mcp._tool_manager.get_tools())
     for name, tool in tools.items():
         assert tool.description, f"Tool {name} has no description"
+
+
+def test_points_rules_is_resource():
+    resources = asyncio.run(mcp._resource_manager.get_resources())
+    assert "config://points-rules" in resources
 
 
 def test_login_tool_has_required_params():

--- a/mcp_server/tests/test_server.py
+++ b/mcp_server/tests/test_server.py
@@ -1,0 +1,40 @@
+import asyncio
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from server import mcp
+
+
+def test_server_loads_all_tools():
+    tools = asyncio.run(mcp._tool_manager.get_tools())
+    assert len(tools) >= 50
+    expected = [
+        "login",
+        "get_current_user",
+        "list_store_items",
+        "list_chores",
+        "get_parent_dashboard",
+        "get_kid_dashboard",
+        "submit_chore",
+        "approve_chore_submission",
+        "create_pet",
+        "get_points_rules",
+    ]
+    for name in expected:
+        assert name in tools, f"Missing tool: {name}"
+
+
+def test_tool_descriptions_exist():
+    tools = asyncio.run(mcp._tool_manager.get_tools())
+    for name, tool in tools.items():
+        assert tool.description, f"Tool {name} has no description"
+
+
+def test_login_tool_has_required_params():
+    tools = asyncio.run(mcp._tool_manager.get_tools())
+    login_tool = tools["login"]
+    schema = login_tool.parameters
+    assert "username" in schema.get("properties", {})
+    assert "password" in schema.get("properties", {})


### PR DESCRIPTION
## Summary
- **Response envelope middleware** wrapping all API responses in `{success, data, error, meta}` format with frontend interceptor to unwrap transparently
- **Auth enforcement** on 15+ previously unprotected endpoints, plus GET-by-ID and dashboard APIs
- **Pagination and query filtering** on all list endpoints with `limit`, `offset`, and `status` filters
- **MCP server** with 71 tools wrapping the full Kids Rewards API, including auto-auth via API key env var and 401 retry
- **API key authentication** (`POST /users/me/api-key` + `POST /auth/api-key`) so MCP server never exposes passwords in conversation history
- **9 field mismatch fixes** in MCP tool bodies/endpoints found during systematic tool verification
- **132 tests** (128 backend + 4 MCP), all passing

## Test plan
- [x] Backend tests pass (128 tests)
- [x] MCP server tests pass (4 tests)
- [x] Ruff lint clean
- [x] Manual e2e: generated API key, exchanged for JWT, verified MCP auto-auth
- [x] Systematic verification of all 71 MCP tools against live backend
- [ ] CI tests pass on GitHub Actions
- [ ] Deploy to production and generate production API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)